### PR TITLE
fix: correct redirect in AuthGuard to root /

### DIFF
--- a/components/auth/auth-guard.tsx
+++ b/components/auth/auth-guard.tsx
@@ -40,10 +40,10 @@ export function AuthGuard({ children }: AuthGuardProps) {
           return
         }
 
-        // Si está autenticado y está en login, redirigir a dashboard
+        // Si está autenticado y está en login, redirigir a la página principal
         if (isAuth && pathname === "/login") {
           hasRedirectedRef.current = true
-          window.location.href = "/dashboard"
+          window.location.href = "/"
           return
         }
       } catch (err) {


### PR DESCRIPTION
Fix redirect from `/dashboard` to `/` after successful login.

#VERCEL_SKIP