### PR TITLE
fix: apply golden master fixes to case-form and animated-cases-grid

### DIFF
--- a/components/cases/animated-cases-grid.tsx
+++ b/components/cases/animated-cases-grid.tsx
@@ -146,38 +146,37 @@ export function AnimatedCasesGrid() {
           hechos (
             id,
             fecha_hecho,
-            lugar_especifico,
+            municipio,
             provincia,
             seguimiento (
-              contacto_familia
+              contacto_familia,
+              parentesco_contacto
             ),
             imputados (
               estado_procesal
             )
           )
         `)
+        .order("created_at", { ascending: false })
         .limit(12)
 
       if (victimError) throw victimError
 
       // Transform data to match component interface
-      const transformedCases: CaseData[] = victimData.map((victim: any) => {
+      const transformedCases: CaseData[] = (victimData || []).map((victim: any) => {
         const incident = victim.hechos?.[0] || {}
         const followUp = incident.seguimiento?.[0] || {}
         const imputado = incident.imputados?.[0] || {}
-
-        // Parse family contact to extract name and relationship
-        const familyContactParts = followUp.contacto_familia?.split(" - ") || ["", ""]
 
         return {
           id: victim.id,
           victimName: victim.nombre_completo || "Sin nombre",
           incidentDate: incident.fecha_hecho || new Date().toISOString(),
-          location: incident.lugar_especifico || "No especificado",
+          location: incident.municipio || "No especificado",
           province: incident.provincia || "No especificado",
           status: imputado.estado_procesal || "En investigación",
-          familyContactName: familyContactParts[0] || "No especificado",
-          familyRelationship: familyContactParts[1] || "Familiar",
+          familyContactName: followUp.contacto_familia || "No especificado",
+          familyRelationship: followUp.parentesco_contacto || "Familiar",
         }
       })
 

--- a/components/cases/case-form.tsx
+++ b/components/cases/case-form.tsx
@@ -856,7 +856,7 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="max-w-5xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <Link href="/casos">


### PR DESCRIPTION
Align header and tabs in case-form; clean up deprecated columns in animated-cases-grid.

#VERCEL_SKIP