### PR TITLE
perf: auditoría de performance + fixes en case-form

### DIFF
--- a/app/casos/page.tsx
+++ b/app/casos/page.tsx
@@ -8,20 +8,7 @@ import { Button } from "@/components/ui/button"
 import { MapPin, User, Loader2, ChevronLeft, ChevronRight, ArrowLeft, Phone, Users } from "lucide-react"
 import { createClient } from "@/lib/supabase/client"
 import { CasesFilters } from "@/components/cases/cases-filters"
-
-interface CaseData {
-  id: string
-  victimName: string
-  incidentDate: string
-  location: string
-  province: string
-  status: string
-  familyContactName: string
-  familyRelationship: string
-  familyContactPhone: string
-  hechoId: string
-  totalVictimsInHecho: number
-}
+import { fetchCasesList, type CaseListItem } from "@/lib/data/casos"
 
 const getStatusColor = (status: string) => {
   switch (status) {
@@ -49,7 +36,7 @@ const getStatusColor = (status: string) => {
 }
 
 interface CaseCardProps {
-  case: CaseData
+  case: CaseListItem
 }
 
 function CaseCard({ case: caseData }: CaseCardProps) {
@@ -77,7 +64,7 @@ function CaseCard({ case: caseData }: CaseCardProps) {
               <div className="flex items-center gap-2">
                 <MapPin className="w-4 h-4 text-blue-600" />
                 <span className="line-clamp-1">
-                  {caseData.location}, {caseData.province}
+                  {caseData.municipio}, {caseData.provincia}
                 </span>
               </div>
 
@@ -103,8 +90,8 @@ function CaseCard({ case: caseData }: CaseCardProps) {
 }
 
 export default function CasosPage() {
-  const [cases, setCases] = useState<CaseData[]>([])
-  const [filteredCases, setFilteredCases] = useState<CaseData[]>([])
+  const [cases, setCases] = useState<CaseListItem[]>([])
+  const [filteredCases, setFilteredCases] = useState<CaseListItem[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
@@ -133,95 +120,8 @@ export default function CasosPage() {
     try {
       setIsLoading(true)
       setError(null)
-
-      const { data: casosData, error: casosError } = await supabase
-        .from("casos")
-        .select(`
-          id,
-          estado_general,
-          estado,
-          hecho_id,
-          victima_id,
-          victimas (
-            id,
-            nombre_completo
-          ),
-          hechos (
-            id,
-            fecha_hecho,
-            municipio,
-            provincia
-          )
-        `)
-        .order("created_at", { ascending: false })
-
-      if (casosError) throw casosError
-
-      console.log("[v0] Total casos fetched:", casosData?.length)
-
-      // Group casos by hecho_id to count victims per incident
-      const hechoVictimCounts: Record<string, number> = {}
-      for (const caso of casosData || []) {
-        if (caso.hecho_id) {
-          hechoVictimCounts[caso.hecho_id] = (hechoVictimCounts[caso.hecho_id] || 0) + 1
-        }
-      }
-
-      const transformedCases: CaseData[] = await Promise.all(
-        (casosData || []).map(async (caso: any) => {
-          const victima = caso.victimas || {}
-          const hecho = caso.hechos || {}
-
-          const { data: seguimientoData, error: segError } = await supabase
-            .from("seguimiento")
-            .select("lista_contactos_familiares")
-            .eq("hecho_id", caso.hecho_id)
-            .order("created_at", { ascending: true })
-            .limit(1)
-            .maybeSingle()
-
-          console.log("[v0] Seguimiento for hecho_id", caso.hecho_id, ":", seguimientoData)
-          if (segError && segError.code !== "PGRST116") {
-            console.log("[v0] Error fetching seguimiento:", segError)
-          }
-
-          let familyContactName = "No especificado"
-          let familyRelationship = ""
-          let familyContactPhone = "No especificado"
-
-          if (seguimientoData?.lista_contactos_familiares) {
-            const contactos = seguimientoData.lista_contactos_familiares as any[]
-            if (contactos && contactos.length > 0) {
-              const primerContacto = contactos[0]
-              familyContactName = primerContacto.nombre || "No especificado"
-              familyRelationship = primerContacto.parentesco || ""
-              familyContactPhone = (primerContacto.telefono && primerContacto.telefono.trim()) || "No especificado"
-            }
-          }
-
-          return {
-            id: caso.id,
-            victimName: victima.nombre_completo || "Sin nombre",
-            incidentDate: hecho.fecha_hecho || new Date().toISOString(),
-            location: hecho.municipio || "No especificado",
-            province: hecho.provincia || "No especificado",
-            status:
-              caso.estado && caso.estado.trim() !== ""
-                ? caso.estado
-                : caso.estado_general && caso.estado_general.trim() !== ""
-                  ? caso.estado_general
-                  : "En investigación",
-            familyContactName,
-            familyRelationship,
-            familyContactPhone,
-            hechoId: caso.hecho_id,
-            totalVictimsInHecho: caso.hecho_id ? hechoVictimCounts[caso.hecho_id] : 1,
-          }
-        }),
-      )
-
-      console.log("[v0] Transformed cases sample:", transformedCases.slice(0, 2))
-      setCases(transformedCases)
+      const data = await fetchCasesList(supabase)
+      setCases(data)
     } catch (err) {
       console.error("Error fetching cases:", err)
       setError("Error al cargar los casos")
@@ -238,8 +138,8 @@ export default function CasosPage() {
       filtered = filtered.filter(
         (caseData) =>
           caseData.victimName.toLowerCase().includes(searchLower) ||
-          caseData.location.toLowerCase().includes(searchLower) ||
-          caseData.province.toLowerCase().includes(searchLower),
+          caseData.municipio.toLowerCase().includes(searchLower) ||
+          caseData.provincia.toLowerCase().includes(searchLower),
       )
     }
 
@@ -251,12 +151,12 @@ export default function CasosPage() {
     }
 
     if (filters.province) {
-      filtered = filtered.filter((caseData) => caseData.province === filters.province)
+      filtered = filtered.filter((caseData) => caseData.provincia === filters.province)
     }
 
     if (filters.location) {
       const locationLower = filters.location.toLowerCase()
-      filtered = filtered.filter((caseData) => caseData.location.toLowerCase().includes(locationLower))
+      filtered = filtered.filter((caseData) => caseData.municipio.toLowerCase().includes(locationLower))
     }
 
     if (filters.status) {

--- a/app/casos/page.tsx
+++ b/app/casos/page.tsx
@@ -6,9 +6,9 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { MapPin, User, Loader2, ChevronLeft, ChevronRight, ArrowLeft, Phone, Users } from "lucide-react"
-import { createClient } from "@/lib/supabase/client"
 import { CasesFilters } from "@/components/cases/cases-filters"
-import { fetchCasesList, type CaseListItem } from "@/lib/data/casos"
+import { type CaseListItem } from "@/lib/data/casos"
+import { useCasesList } from "@/lib/queries/casos"
 
 const getStatusColor = (status: string) => {
   switch (status) {
@@ -90,10 +90,8 @@ function CaseCard({ case: caseData }: CaseCardProps) {
 }
 
 export default function CasosPage() {
-  const [cases, setCases] = useState<CaseListItem[]>([])
+  const { data: cases = [], isLoading, error, refetch } = useCasesList()
   const [filteredCases, setFilteredCases] = useState<CaseListItem[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const [filters, setFilters] = useState({
     dateFrom: "",
@@ -106,29 +104,10 @@ export default function CasosPage() {
   })
 
   const casesPerPage = 12
-  const supabase = createClient()
-
-  useEffect(() => {
-    fetchCases()
-  }, [])
 
   useEffect(() => {
     applyFilters()
   }, [cases, filters])
-
-  const fetchCases = async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
-      const data = await fetchCasesList(supabase)
-      setCases(data)
-    } catch (err) {
-      console.error("Error fetching cases:", err)
-      setError("Error al cargar los casos")
-    } finally {
-      setIsLoading(false)
-    }
-  }
 
   const applyFilters = () => {
     let filtered = [...cases]
@@ -196,8 +175,8 @@ export default function CasosPage() {
       <div className="container mx-auto px-4 py-8">
         <div className="text-center py-12">
           <h1 className="text-3xl font-bold text-slate-900 font-heading mb-4">Error</h1>
-          <p className="text-lg text-slate-600 max-w-2xl mx-auto mb-8">{error}</p>
-          <Button onClick={fetchCases} className="bg-blue-600 hover:bg-blue-700">
+          <p className="text-lg text-slate-600 max-w-2xl mx-auto mb-8">Error al cargar los casos</p>
+          <Button onClick={() => refetch()} className="bg-blue-600 hover:bg-blue-700">
             Reintentar
           </Button>
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Lato, Montserrat } from "next/font/google"
 import "./globals.css"
 import { AuthGuard } from "@/components/auth/auth-guard"
 import { SupabaseListener } from "@/components/auth/supabase-listener"
+import { QueryProvider } from "@/components/providers/query-provider"
 
 const lato = Lato({
   subsets: ["latin"],
@@ -33,8 +34,10 @@ export default function RootLayout({
   return (
     <html lang="es" className={`${lato.variable} ${montserrat.variable}`}>
       <body className="font-sans antialiased bg-slate-50 text-slate-900">
-        <SupabaseListener />
-        <AuthGuard>{children}</AuthGuard>
+        <QueryProvider>
+          <SupabaseListener />
+          <AuthGuard>{children}</AuthGuard>
+        </QueryProvider>
       </body>
     </html>
   )

--- a/components/auth/auth-guard.tsx
+++ b/components/auth/auth-guard.tsx
@@ -2,119 +2,41 @@
 
 import type React from "react"
 
-import { useEffect, useState, useRef } from "react"
+import { useEffect } from "react"
 import { usePathname, useRouter } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
-import { Loader2 } from "lucide-react"
-
-const DEV_BYPASS_AUTH = false
 
 interface AuthGuardProps {
   children: React.ReactNode
 }
 
+/**
+ * Sólo escucha el evento `SIGNED_OUT` para redirigir al login cuando
+ * la sesión se cierra en otra pestaña o expira.
+ *
+ * El chequeo de sesión + whitelist se hace en `lib/supabase/middleware.ts`
+ * antes de que la página se sirva al cliente. Por eso este componente
+ * ya no monta un spinner bloqueante de "Verificando acceso" en el
+ * primer render.
+ */
 export function AuthGuard({ children }: AuthGuardProps) {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null)
   const pathname = usePathname()
   const router = useRouter()
-  const hasRedirectedRef = useRef(false)
-  const supabase = createClient()
 
   useEffect(() => {
-    if (DEV_BYPASS_AUTH) {
-      console.log("[v0] Modo DEV activo - Bypass de autenticación habilitado")
-      setIsAuthenticated(true)
-      return
-    }
-
-    let isMounted = true
-
-    const checkAuth = async () => {
-      try {
-        const {
-          data: { session },
-          error,
-        } = await supabase.auth.getSession()
-
-        if (!isMounted) return
-
-        const isAuth = !!session && !error
-        setIsAuthenticated(isAuth)
-
-        // Si no está autenticado y no está en login, redirigir a login
-        if (!isAuth && pathname !== "/login") {
-          hasRedirectedRef.current = true
-          router.replace("/login")
-          return
-        }
-
-        // Si está autenticado y está en login, redirigir a la página principal
-        if (isAuth && pathname === "/login") {
-          hasRedirectedRef.current = true
-          router.replace("/")
-          return
-        }
-      } catch (err) {
-        if (isMounted) {
-          setIsAuthenticated(false)
-          if (pathname !== "/login") {
-            hasRedirectedRef.current = true
-            router.replace("/login")
-          }
-        }
-      }
-    }
-
+    const supabase = createClient()
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, session) => {
-      if (!isMounted || hasRedirectedRef.current) return
-
-      const isAuth = !!session
-      setIsAuthenticated(isAuth)
-
+    } = supabase.auth.onAuthStateChange((event) => {
       if (event === "SIGNED_OUT" && pathname !== "/login") {
-        hasRedirectedRef.current = true
         router.replace("/login")
       }
     })
 
-    checkAuth()
-
     return () => {
-      isMounted = false
       subscription.unsubscribe()
     }
-  }, [supabase, pathname, router])
+  }, [pathname, router])
 
-  if (isAuthenticated === null) {
-    return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
-        <div className="text-center">
-          <Loader2 className="h-8 w-8 animate-spin text-blue-600 mx-auto mb-4" />
-          <p className="text-slate-600">Verificando acceso...</p>
-        </div>
-      </div>
-    )
-  }
-
-  // Si está en la página de login, siempre mostrar
-  if (pathname === "/login") {
-    return <>{children}</>
-  }
-
-  // Si está autenticado, mostrar contenido protegido
-  if (isAuthenticated) {
-    return <>{children}</>
-  }
-
-  // Si no está autenticado, mostrar loading mientras redirige
-  return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center">
-      <div className="text-center">
-        <Loader2 className="h-8 w-8 animate-spin text-blue-600 mx-auto mb-4" />
-        <p className="text-slate-600">Redirigiendo al login...</p>
-      </div>
-    </div>
-  )
+  return <>{children}</>
 }

--- a/components/cases/animated-cases-grid.tsx
+++ b/components/cases/animated-cases-grid.tsx
@@ -5,8 +5,8 @@ import Link from "next/link"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { MapPin, User, Loader2, Users } from "lucide-react"
-import { createClient } from "@/lib/supabase/client"
-import { fetchCasesList, type CaseListItem } from "@/lib/data/casos"
+import { type CaseListItem } from "@/lib/data/casos"
+import { useCasesList } from "@/lib/queries/casos"
 
 type CaseData = CaseListItem
 
@@ -115,15 +115,8 @@ function ScrollingRow({ cases, direction, speed }: ScrollingRowProps) {
 }
 
 export function AnimatedCasesGrid() {
-  const [cases, setCases] = useState<CaseData[]>([])
+  const { data: cases = [], isLoading, error, refetch } = useCasesList()
   const [rows, setRows] = useState<CaseData[][]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const supabase = createClient()
-
-  useEffect(() => {
-    fetchCases()
-  }, [])
 
   useEffect(() => {
     if (cases.length > 0) {
@@ -135,20 +128,6 @@ export function AnimatedCasesGrid() {
       setRows(caseRows)
     }
   }, [cases])
-
-  const fetchCases = async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
-      const data = await fetchCasesList(supabase)
-      setCases(data)
-    } catch (err) {
-      console.error("Error fetching cases:", err)
-      setError("Error al cargar los casos")
-    } finally {
-      setIsLoading(false)
-    }
-  }
 
   if (isLoading) {
     return (
@@ -164,10 +143,10 @@ export function AnimatedCasesGrid() {
       <div className="text-center py-12">
         <h2 className="text-3xl font-bold text-slate-900 font-heading mb-4">Casos Recientes</h2>
         <p className="text-lg text-slate-600 max-w-2xl mx-auto mb-8">
-          {error || "No hay casos disponibles para mostrar"}
+          {error ? "Error al cargar los casos" : "No hay casos disponibles para mostrar"}
         </p>
         {error && (
-          <button onClick={fetchCases} className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+          <button onClick={() => refetch()} className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
             Reintentar
           </button>
         )}

--- a/components/cases/animated-cases-grid.tsx
+++ b/components/cases/animated-cases-grid.tsx
@@ -6,20 +6,9 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { MapPin, User, Loader2, Users } from "lucide-react"
 import { createClient } from "@/lib/supabase/client"
+import { fetchCasesList, type CaseListItem } from "@/lib/data/casos"
 
-interface CaseData {
-  id: string
-  victimName: string
-  incidentDate: string
-  location: string
-  province: string
-  status: string
-  familyContactName: string
-  familyRelationship: string
-  familyContactPhone: string
-  hechoId: string
-  totalVictimsInHecho: number
-}
+type CaseData = CaseListItem
 
 const getStatusColor = (status: string) => {
   switch (status) {
@@ -66,7 +55,9 @@ function CaseCard({ case: caseData }: CaseCardProps) {
             <div className="space-y-2 text-sm text-slate-600">
               <div className="flex items-center gap-2">
                 <MapPin className="w-4 h-4 text-blue-600" />
-                <span className="line-clamp-1">{caseData.location}</span>
+                <span className="line-clamp-1">
+                  {caseData.municipio !== "No especificado" ? caseData.municipio : caseData.provincia}
+                </span>
               </div>
 
               <div className="flex items-center gap-2">
@@ -149,102 +140,8 @@ export function AnimatedCasesGrid() {
     try {
       setIsLoading(true)
       setError(null)
-
-      const { data: casosData, error: casosError } = await supabase
-        .from("casos")
-        .select(`
-          id,
-          estado_general,
-          estado,
-          hecho_id,
-          victima_id,
-          created_at,
-          victimas (
-            id,
-            nombre_completo
-          ),
-          hechos (
-            id,
-            fecha_hecho,
-            municipio,
-            provincia
-          )
-        `)
-        .order("created_at", { ascending: false })
-
-      if (casosError) throw casosError
-
-      const hechoVictimCounts: Record<string, number> = {}
-      for (const caso of casosData || []) {
-        if (caso.hecho_id) {
-          hechoVictimCounts[caso.hecho_id] = (hechoVictimCounts[caso.hecho_id] || 0) + 1
-        }
-      }
-
-      const transformedCases: CaseData[] = await Promise.all(
-        (casosData || []).map(async (caso: any) => {
-          const victima = caso.victimas || {}
-          const hecho = caso.hechos || {}
-
-          console.log(
-            `[v0] Caso ${victima.nombre_completo || "Sin nombre"} - estado: "${caso.estado}", estado_general: "${caso.estado_general}"`,
-          )
-
-          const { data: seguimientoData, error: segError } = await supabase
-            .from("seguimiento")
-            .select("lista_contactos_familiares")
-            .eq("hecho_id", caso.hecho_id)
-            .order("created_at", { ascending: true })
-            .limit(1)
-            .maybeSingle()
-
-          if (segError && segError.code !== "PGRST116") {
-            console.log("[v0] Error fetching seguimiento:", segError)
-          }
-
-          let familyContactName = "No especificado"
-          let familyRelationship = "Familiar"
-          let familyContactPhone = "No especificado"
-
-          if (seguimientoData?.lista_contactos_familiares) {
-            const contactos = seguimientoData.lista_contactos_familiares as any[]
-            if (contactos && contactos.length > 0) {
-              const primerContacto = contactos[0]
-              familyContactName = primerContacto.nombre || "No especificado"
-              familyRelationship = primerContacto.parentesco || "Familiar"
-              const telefono = primerContacto.telefono
-              familyContactPhone = telefono && telefono.trim() !== "" ? telefono : "No especificado"
-            }
-          }
-
-          const finalStatus =
-            caso.estado && caso.estado.trim() !== ""
-              ? caso.estado
-              : caso.estado_general && caso.estado_general.trim() !== ""
-                ? caso.estado_general
-                : "En investigación"
-
-          console.log(`[v0] Caso ${victima.nombre_completo || "Sin nombre"} - status final: "${finalStatus}"`)
-
-          return {
-            id: caso.id,
-            victimName: victima.nombre_completo || "Sin nombre",
-            incidentDate: hecho.fecha_hecho || new Date().toISOString(),
-            location: hecho.municipio || hecho.provincia || "No especificado",
-            province: hecho.provincia || "No especificado",
-            status: finalStatus,
-            familyContactName,
-            familyRelationship,
-            familyContactPhone,
-            hechoId: caso.hecho_id,
-            totalVictimsInHecho: caso.hecho_id ? hechoVictimCounts[caso.hecho_id] : 1,
-          }
-        }),
-      )
-
-      console.log("[v0] Transformed cases sample:", transformedCases.slice(0, 2))
-
-      setCases(transformedCases)
+      const data = await fetchCasesList(supabase)
+      setCases(data)
     } catch (err) {
       console.error("Error fetching cases:", err)
       setError("Error al cargar los casos")

--- a/components/cases/animated-cases-grid.tsx
+++ b/components/cases/animated-cases-grid.tsx
@@ -40,9 +40,12 @@ interface CaseCardProps {
 }
 
 function CaseCard({ case: caseData }: CaseCardProps) {
+  // `content-visibility: auto` + `contain-intrinsic-size` evitan
+  // pintar y layoutear las cards que están fuera del viewport mientras
+  // el marquee las arrastra (la mayoría del tiempo).
   return (
     <Link href={`/casos/${caseData.id}`}>
-      <Card className="w-80 flex-shrink-0 hover:shadow-lg transition-all duration-300 border-slate-200 hover:border-blue-300 cursor-pointer hover:scale-105">
+      <Card className="w-80 flex-shrink-0 hover:shadow-lg transition-all duration-300 border-slate-200 hover:border-blue-300 cursor-pointer hover:scale-105 [content-visibility:auto] [contain-intrinsic-size:auto_220px]">
         <CardContent className="p-6">
           <div className="space-y-4">
             <div>
@@ -104,6 +107,10 @@ function ScrollingRow({ cases, direction, speed }: ScrollingRowProps) {
         className={`flex gap-6 ${direction === "left" ? "animate-scroll-left" : "animate-scroll-right"}`}
         style={{
           animationDuration: `${speed}s`,
+          // Avisa al navegador que esta capa va a transformarse en cada
+          // frame para que la promueva a su propia compositor layer y
+          // evite repaints del layout principal.
+          willChange: "transform",
         }}
       >
         {duplicatedCases.map((caseData, index) => (
@@ -114,11 +121,18 @@ function ScrollingRow({ cases, direction, speed }: ScrollingRowProps) {
   )
 }
 
+// Vista animada de la home: vitrina, no listado completo. Limitamos a
+// los más recientes para no triplicar 200 cards en el DOM (3x = animación
+// de marquee). Con la query ordenada por created_at desc esto deja los
+// últimos 24 casos -> 6 filas de 4 -> ~72 nodos animados en el DOM.
+const VITRINA_MAX_CASES = 24
+
 export function AnimatedCasesGrid() {
-  const { data: cases = [], isLoading, error, refetch } = useCasesList()
+  const { data: allCases = [], isLoading, error, refetch } = useCasesList()
   const [rows, setRows] = useState<CaseData[][]>([])
 
   useEffect(() => {
+    const cases = allCases.slice(0, VITRINA_MAX_CASES)
     if (cases.length > 0) {
       const chunkSize = 4
       const caseRows = []
@@ -127,7 +141,10 @@ export function AnimatedCasesGrid() {
       }
       setRows(caseRows)
     }
-  }, [cases])
+  }, [allCases])
+
+  // Para chequeos de "no hay nada" usamos el dataset original (no la slice).
+  const cases = allCases
 
   if (isLoading) {
     return (

--- a/components/cases/case-detail-content.tsx
+++ b/components/cases/case-detail-content.tsx
@@ -47,6 +47,8 @@ import {
 import { createClient } from "@/lib/supabase/client"
 import { FilePreviewDialog } from "@/components/ui/file-preview-dialog"
 import { formatDateUTC } from "@/lib/utils"
+import { useQueryClient } from "@tanstack/react-query"
+import { queryKeys } from "@/lib/queries/keys"
 
 interface CaseDetailContentProps {
   caseId: string
@@ -336,6 +338,7 @@ export function CaseDetailContent({ caseId }: CaseDetailContentProps) {
   const [error, setError] = useState<string | null>(null)
   const router = useRouter()
   const supabase = createClient()
+  const queryClient = useQueryClient()
 
   useEffect(() => {
     fetchCaseData()
@@ -541,6 +544,9 @@ export function CaseDetailContent({ caseId }: CaseDetailContentProps) {
       setIsDeleting(true)
       const { error } = await supabase.from("casos").delete().eq("id", caseId)
       if (error) throw error
+      // Listados y dashboard quedaron stale tras el delete.
+      queryClient.invalidateQueries({ queryKey: queryKeys.casesList })
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboardStats })
       router.push("/casos")
     } catch (err) {
       console.error("Error deleting case:", err)

--- a/components/cases/case-detail-content.tsx
+++ b/components/cases/case-detail-content.tsx
@@ -454,72 +454,74 @@ export function CaseDetailContent({ caseId }: CaseDetailContentProps) {
     estadoGeneral: string | null,
     estado: string | null = null,
   ) => {
-    // Get imputados
-    let imputadosData: Imputado[] = []
-    if (hechoData?.id) {
-      const { data: imputadosArray } = await supabase.from("imputados").select("*").eq("hecho_id", hechoData.id)
+    // Stage 1: queries independientes en paralelo.
+    // - imputados con instancias_judiciales embebidas (elimina el N+1 anterior)
+    // - seguimiento del hecho
+    // - hermanos de hecho (otras víctimas del mismo hecho)
+    const hechoId: string | undefined = hechoData?.id
+    const victimaId: string | undefined = victimaData?.id
 
-      imputadosData = await Promise.all(
-        (imputadosArray || []).map(async (imp: any) => {
-          const { data: instanciasArray } = await supabase
-            .from("instancias_judiciales")
-            .select("*")
-            .eq("imputado_id", imp.id)
+    const [imputadosResult, seguimientoResult, hermanosResult] =
+      await Promise.all([
+        hechoId
+          ? supabase
+              .from("imputados")
+              .select("*, instancias_judiciales(*)")
+              .eq("hecho_id", hechoId)
+          : Promise.resolve({ data: [] as any[] }),
+        hechoId
+          ? supabase.from("seguimiento").select("*").eq("hecho_id", hechoId)
+          : Promise.resolve({ data: [] as any[] }),
+        hechoId && victimaId
+          ? supabase
+              .from("casos")
+              .select("id, victima_id, victimas(nombre_completo)")
+              .eq("hecho_id", hechoId)
+              .neq("victima_id", victimaId)
+          : Promise.resolve({ data: [] as any[] }),
+      ])
 
-          return {
-            ...imp,
-            instancias_judiciales: instanciasArray || [],
-          }
-        }),
-      )
-    }
+    const imputadosData: Imputado[] = (imputadosResult.data || []).map(
+      (imp: any) => ({
+        ...imp,
+        instancias_judiciales: imp.instancias_judiciales || [],
+      }),
+    )
 
-    // Get seguimiento
-    let seguimientoData: Seguimiento | null = null
-    if (hechoData?.id) {
-      const { data: seguimientoArray } = await supabase.from("seguimiento").select("*").eq("hecho_id", hechoData.id)
-      seguimientoData = seguimientoArray?.[0] || null
+    const seguimientoData: Seguimiento | null =
+      (seguimientoResult.data || [])[0] || null
+
+    const hermanosHecho: HermanoHecho[] = (hermanosResult.data || []).map(
+      (c: any) => ({
+        caso_id: c.id,
+        victima_id: c.victima_id,
+        victima_nombre: c.victimas?.nombre_completo || "Sin nombre",
+      }),
+    )
+
+    // Stage 2: un único fetch de recursos para hecho + víctima + imputados.
+    // Antes eran 2 + N queries (una por imputado); ahora es 1 sola con `.or()`.
+    const imputadoIds = imputadosData.map((i) => i.id)
+    const recursosFilters: string[] = []
+    if (hechoId) recursosFilters.push(`hecho_id.eq.${hechoId}`)
+    if (victimaId) recursosFilters.push(`victima_id.eq.${victimaId}`)
+    if (imputadoIds.length) {
+      recursosFilters.push(`imputado_id.in.(${imputadoIds.join(",")})`)
     }
 
     let recursosData: Recurso[] = []
-
-    // Get hecho-level recursos
-    if (hechoData?.id) {
-      const { data: hechoRecursos } = await supabase.from("recursos").select("*").eq("hecho_id", hechoData.id)
-      recursosData = [...recursosData, ...(hechoRecursos || [])]
+    if (recursosFilters.length) {
+      const { data: recursos } = await supabase
+        .from("recursos")
+        .select("*")
+        .or(recursosFilters.join(","))
+      recursosData = recursos || []
     }
 
-    // Get victim-specific recursos
-    if (victimaData?.id) {
-      const { data: victimRecursos } = await supabase.from("recursos").select("*").eq("victima_id", victimaData.id)
-      recursosData = [...recursosData, ...(victimRecursos || [])]
-    }
-
-    // Get imputado-specific recursos
-    for (const imp of imputadosData) {
-      const { data: impRecursos } = await supabase.from("recursos").select("*").eq("imputado_id", imp.id)
-      recursosData = [...recursosData, ...(impRecursos || [])]
-    }
-
-    // Remove duplicates by id
-    const uniqueRecursos = recursosData.filter((r, index, self) => index === self.findIndex((t) => t.id === r.id))
-
-    // Get hermanos de hecho
-    let hermanosHecho: HermanoHecho[] = []
-    if (hechoData?.id) {
-      const { data: otrosCasosArray } = await supabase
-        .from("casos")
-        .select("id, victima_id, victimas(nombre_completo)")
-        .eq("hecho_id", hechoData.id)
-        .neq("victima_id", victimaData?.id)
-
-      hermanosHecho =
-        (otrosCasosArray || []).map((c: any) => ({
-          caso_id: c.id,
-          victima_id: c.victima_id,
-          victima_nombre: c.victimas?.nombre_completo || "Sin nombre",
-        })) || []
-    }
+    // Dedup por id (un recurso puede matchear más de un filtro).
+    const uniqueRecursos = recursosData.filter(
+      (r, index, self) => index === self.findIndex((t) => t.id === r.id),
+    )
 
     setCaseData({
       caso_id: casoId,

--- a/components/cases/case-form.tsx
+++ b/components/cases/case-form.tsx
@@ -15,6 +15,8 @@ import { ResourcesForm } from "./forms/resources-form"
 import { useToast } from "@/hooks/use-toast"
 import { createClient } from "@/lib/supabase/client"
 import { Badge } from "@/components/ui/badge"
+import { useQueryClient } from "@tanstack/react-query"
+import { queryKeys } from "@/lib/queries/keys"
 
 interface CaseFormProps {
   mode: "create" | "edit"
@@ -41,6 +43,7 @@ const getEmptyVictimData = () => ({
 export function CaseForm({ mode, caseId }: CaseFormProps) {
   const router = useRouter()
   const { toast } = useToast()
+  const queryClient = useQueryClient()
   const [activeTab, setActiveTab] = useState("victim")
   const [isSaving, setIsSaving] = useState(false)
   const [isLoading, setIsLoading] = useState(mode === "edit")
@@ -1226,6 +1229,10 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
             ? "Los cambios han sido guardados correctamente."
             : `Se han registrado ${formData.victims.length} víctima(s) correctamente.`,
       })
+
+      // Listados y dashboard quedaron stale tras el insert/update.
+      queryClient.invalidateQueries({ queryKey: queryKeys.casesList })
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboardStats })
 
       router.push("/casos")
     } catch (error: any) {

--- a/components/cases/case-form.tsx
+++ b/components/cases/case-form.tsx
@@ -68,7 +68,6 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
       otraIntervencionDescripcion: "",
     },
     resources: [],
-    victimResources: [],
   })
 
   const [realIds, setRealIds] = useState<{
@@ -269,41 +268,14 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
         }
       }
 
-      // Load seguimiento
-      const { data: seguimientoData } = await supabase.from("seguimiento").select("*").eq("hecho_id", hechoId).single()
+      // Load seguimiento. `.maybeSingle()` no rompe cuando el hecho aún no
+      // tiene una fila de seguimiento (caso real para fichas viejas).
+      const { data: seguimientoData } = await supabase.from("seguimiento").select("*").eq("hecho_id", hechoId).maybeSingle()
 
-      if (seguimientoData) {
-        setFormData((prev) => ({
-          ...prev,
-          followUp: {
-            primerContacto: seguimientoData.primer_contacto || false,
-            comoLlegoCaso: seguimientoData.como_llego_caso || "",
-            miembroAsignado: seguimientoData.miembro_asignado || "",
-            contactoFamiliar: seguimientoData.contacto_familia || "",
-            telefonoContacto: seguimientoData.telefono_contacto || "",
-            tipoAcompanamiento: seguimientoData.tipo_acompanamiento || [],
-            abogadoQuerellante: seguimientoData.abogado_querellante || "",
-            amicusCuriae: seguimientoData.amicus_curiae || false,
-            notasSeguimiento: seguimientoData.notas_seguimiento || "",
-            emailContacto: seguimientoData.email_contacto || "",
-            direccionContacto: seguimientoData.direccion_contacto || "",
-            telefonoMiembro: seguimientoData.telefono_miembro || "",
-            emailMiembro: seguimientoData.email_miembro || "",
-            fechaAsignacion: seguimientoData.fecha_asignacion || "",
-            proximasAcciones: seguimientoData.proximas_acciones || "",
-            parentescoContacto: seguimientoData.parentesco_contacto || "",
-            parentescoOtro: seguimientoData.parentesco_otro || "",
-            tieneAbogadoQuerellante: seguimientoData.tiene_abogado_querellante || "ns_nc",
-            abogadoUsinaAmicus: seguimientoData.abogado_usina_amicus || "",
-            abogadoAmicusFirmante: seguimientoData.abogado_amicus_firmante || "",
-            listaMiembrosAsignados: seguimientoData.lista_miembros_asignados || [],
-            listaContactosFamiliares: seguimientoData.lista_contactos_familiares || [],
-            datosAbogadosQuerellantes: seguimientoData.datos_abogados_querellantes || [],
-            otraIntervencion: seguimientoData.otra_intervencion || false,
-            otraIntervencionDescripcion: seguimientoData.otra_intervencion_descripcion || "",
-          },
-        }))
-      }
+      // Antes había acá un setFormData parcial sólo de `followUp`; abajo
+      // el setFormData completo lo cubre con los mismos campos. Quitado
+      // para evitar re-renders y la confusión de mantener dos lugares
+      // en sync.
 
       // Fetch imputados
       let imputadosData: any[] = []
@@ -445,7 +417,6 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
           archivo_size: r.archivo_size,
           input_mode: r.archivo_path ? "file" : "url",
         })),
-        victimResources: [],
       })
     } catch (error: any) {
       toast({
@@ -482,6 +453,27 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
     fallecido: accused.fallecido || false,
     es_reincidente: accused.esReincidente || false,
     cargos: accused.cargos || null,
+  })
+
+  // Un recurso es "existente en BD" si su id es un UUID v4 real (36 chars
+  // con guiones, no empieza con "temp-"). El resto (null, "", "temp-*",
+  // numérico, o con flag isNew) es un recurso recién agregado en el form.
+  // Antes esta misma lógica estaba copiada 3 veces en handleSave.
+  const isExistingResource = (r: any): boolean =>
+    typeof r.id === "string" &&
+    r.id.length === 36 &&
+    r.id.includes("-") &&
+    !r.id.startsWith("temp-")
+
+  // Campos editables de un recurso. Los `archivo_*` no se actualizan acá:
+  // si el usuario reemplaza un archivo, el flujo es borrar el recurso
+  // viejo (resourcesToDelete) y crear uno nuevo.
+  const buildResourceUpdate = (resource: any) => ({
+    tipo: resource.tipo && resource.tipo !== "" ? resource.tipo : "other",
+    titulo: resource.titulo || resource.archivo_nombre || "Sin título",
+    url: resource.url || null,
+    fuente: resource.fuente || null,
+    descripcion: resource.descripcion || null,
   })
 
   const addVictim = () => {
@@ -526,7 +518,7 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
             const pathsToDelete = resourcesToRemove.map((r) => r.archivo_path).filter((p): p is string => !!p)
 
             if (pathsToDelete.length > 0) {
-              await supabase.storage.from("case-files").remove(pathsToDelete)
+              await supabase.storage.from("archivos-casos").remove(pathsToDelete)
             }
           }
 
@@ -558,36 +550,29 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
 
             if (victimError) throw victimError
 
-            // Update victim resources
+            // Update + insert de recursos de la víctima.
             if (victim.resources && Array.isArray(victim.resources) && victim.resources.length > 0) {
-              const newVictimResources = victim.resources.filter((r: any) => {
-                const hasNoId = !r.id || r.id === ""
-                const hasTempId = typeof r.id === "string" && r.id.startsWith("temp-")
-                const hasNumericId = typeof r.id === "number"
-                const hasNewFlag = r.isNew === true
-                const hasRealUUID =
-                  typeof r.id === "string" && r.id.length === 36 && r.id.includes("-") && !r.id.startsWith("temp-")
+              // 1) Actualizar los que ya estaban en BD por si fueron editados.
+              for (const resource of victim.resources.filter(isExistingResource)) {
+                const { error: updateError } = await supabase
+                  .from("recursos")
+                  .update(buildResourceUpdate(resource))
+                  .eq("id", resource.id)
+                if (updateError) throw updateError
+              }
 
-                return !hasRealUUID && (hasNoId || hasTempId || hasNumericId || hasNewFlag)
-              })
-
-              // Solo guardar si tiene archivo o URL
-              for (const resource of newVictimResources) {
+              // 2) Insertar los nuevos (sólo si tienen archivo o URL).
+              for (const resource of victim.resources.filter((r: any) => !isExistingResource(r))) {
                 if (resource.url || resource.archivo_path) {
-                  const resourceData = {
+                  const { error: resourceError } = await supabase.from("recursos").insert([{
                     victima_id: victim.id,
                     hecho_id: hechoId,
-                    tipo: resource.tipo && resource.tipo !== "" ? resource.tipo : "other",
-                    titulo: resource.titulo || resource.archivo_nombre || "Sin título",
-                    url: resource.url || null,
-                    fuente: resource.fuente || null,
-                    descripcion: resource.descripcion || null,
+                    ...buildResourceUpdate(resource),
                     archivo_path: resource.archivo_path || null,
                     archivo_nombre: resource.archivo_nombre || null,
                     archivo_tipo: resource.archivo_tipo || null,
                     archivo_size: resource.archivo_size ? Number(resource.archivo_size) : null,
-                  }
-                  const { error: resourceError } = await supabase.from("recursos").insert([resourceData])
+                  }])
                   if (resourceError) throw resourceError
                 }
               }
@@ -761,13 +746,6 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
                   const hasInstanciaId =
                     instancia.id && typeof instancia.id === "string" && !instancia.id.startsWith("temp-")
 
-                  console.log("[v0] Saving instancia judicial:", {
-                    id: instancia.id,
-                    ordenNivel: instancia.ordenNivel,
-                    numeroCausa: instancia.numeroCausa,
-                    hasInstanciaId,
-                  })
-
                   try {
                     if (hasInstanciaId) {
                       // Update existing instancia
@@ -812,34 +790,27 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
               }
 
               if (accused.resources && Array.isArray(accused.resources)) {
-                const newResources = accused.resources.filter((r: any) => {
-                  const hasNoId = !r.id || r.id === ""
-                  const hasTempId = typeof r.id === "string" && r.id.startsWith("temp-")
-                  const hasNumericId = typeof r.id === "number"
-                  const hasNewFlag = r.isNew === true
-                  const hasRealUUID =
-                    typeof r.id === "string" && r.id.length === 36 && r.id.includes("-") && !r.id.startsWith("temp-")
+                // 1) Update de los que ya estaban en BD.
+                for (const resource of accused.resources.filter(isExistingResource)) {
+                  const { error: updateError } = await supabase
+                    .from("recursos")
+                    .update(buildResourceUpdate(resource))
+                    .eq("id", resource.id)
+                  if (updateError) throw updateError
+                }
 
-                  return !hasRealUUID && (hasNoId || hasTempId || hasNumericId || hasNewFlag)
-                })
-                // Solo guardar si tiene archivo o URL
-                for (const resource of newResources) {
+                // 2) Insert de los nuevos (sólo si tienen archivo o URL).
+                for (const resource of accused.resources.filter((r: any) => !isExistingResource(r))) {
                   if (resource.url || resource.archivo_path) {
-                    await supabase.from("recursos").insert([
-                      {
-                        imputado_id: accusedId,
-                        hecho_id: hechoId,
-                        tipo: resource.tipo && resource.tipo !== "" ? resource.tipo : "other",
-                        titulo: resource.titulo || resource.archivo_nombre || "Sin título",
-                        url: resource.url || null,
-                        fuente: resource.fuente || null,
-                        descripcion: resource.descripcion || null,
-                        archivo_path: resource.archivo_path || null,
-                        archivo_nombre: resource.archivo_nombre || null,
-                        archivo_tipo: resource.archivo_tipo || null,
-                        archivo_size: resource.archivo_size ? Number(resource.archivo_size) : null,
-                      },
-                    ])
+                    await supabase.from("recursos").insert([{
+                      imputado_id: accusedId,
+                      hecho_id: hechoId,
+                      ...buildResourceUpdate(resource),
+                      archivo_path: resource.archivo_path || null,
+                      archivo_nombre: resource.archivo_nombre || null,
+                      archivo_tipo: resource.archivo_tipo || null,
+                      archivo_size: resource.archivo_size ? Number(resource.archivo_size) : null,
+                    }])
                   }
                 }
               }
@@ -963,34 +934,28 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
         }
 
         if (formData.resources && Array.isArray(formData.resources) && formData.resources.length > 0) {
-          const newSeguimientoResources = formData.resources.filter((r: any) => {
-            const hasNoId = !r.id || r.id === ""
-            const hasTempId = typeof r.id === "string" && r.id.startsWith("temp-")
-            const hasNumericId = typeof r.id === "number"
-            const hasNewFlag = r.isNew === true
-            const hasRealUUID =
-              typeof r.id === "string" && r.id.length === 36 && r.id.includes("-") && !r.id.startsWith("temp-")
+          // 1) Update de recursos generales del hecho ya existentes.
+          for (const resource of formData.resources.filter(isExistingResource)) {
+            const { error: updateError } = await supabase
+              .from("recursos")
+              .update(buildResourceUpdate(resource))
+              .eq("id", resource.id)
+            if (updateError) throw updateError
+          }
 
-            return !hasRealUUID && (hasNoId || hasTempId || hasNumericId || hasNewFlag)
-          })
-
-          for (const resource of newSeguimientoResources) {
+          // 2) Insert de los nuevos (sólo si tienen archivo o URL).
+          for (const resource of formData.resources.filter((r: any) => !isExistingResource(r))) {
             if (resource.url || resource.archivo_path) {
-              const resourceData = {
+              const { error: resourceError } = await supabase.from("recursos").insert([{
                 hecho_id: hechoId,
                 imputado_id: null,
                 victima_id: null,
-                tipo: resource.tipo && resource.tipo !== "" ? resource.tipo : "other",
-                titulo: resource.titulo || resource.archivo_nombre || "Sin título",
-                url: resource.url || null,
-                fuente: resource.fuente || null,
-                descripcion: resource.descripcion || null,
+                ...buildResourceUpdate(resource),
                 archivo_path: resource.archivo_path || null,
                 archivo_nombre: resource.archivo_nombre || null,
                 archivo_tipo: resource.archivo_tipo || null,
                 archivo_size: resource.archivo_size ? Number(resource.archivo_size) : null,
-              }
-              const { error: resourceError } = await supabase.from("recursos").insert([resourceData])
+              }])
               if (resourceError) throw resourceError
             }
           }

--- a/components/cases/cases-grid.tsx
+++ b/components/cases/cases-grid.tsx
@@ -7,20 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Calendar, MapPin, User, Search, Loader2, Users } from "lucide-react"
 import { createClient } from "@/lib/supabase/client"
 import { formatDateUTC } from "@/lib/utils"
-
-interface CaseData {
-  id: string
-  victimName: string
-  incidentDate: string
-  location: string
-  province: string
-  status: string
-  familyContactName: string
-  familyRelationship: string
-  familyContactPhone: string
-  hechoId: string
-  totalVictimsInHecho: number
-}
+import { fetchCasesList, type CaseListItem } from "@/lib/data/casos"
 
 const getStatusColor = (status: string) => {
   switch (status) {
@@ -60,7 +47,7 @@ interface CasesGridProps {
 }
 
 export function CasesGrid({ filters = {} }: CasesGridProps) {
-  const [cases, setCases] = useState<CaseData[]>([])
+  const [cases, setCases] = useState<CaseListItem[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const supabase = createClient()
@@ -73,92 +60,8 @@ export function CasesGrid({ filters = {} }: CasesGridProps) {
     try {
       setIsLoading(true)
       setError(null)
-
-      const { data: casosData, error: casosError } = await supabase
-        .from("casos")
-        .select(`
-          id,
-          estado_general,
-          estado,
-          hecho_id,
-          victima_id,
-          created_at,
-          victimas (
-            id,
-            nombre_completo
-          ),
-          hechos (
-            id,
-            fecha_hecho,
-            municipio,
-            provincia
-          )
-        `)
-        .order("created_at", { ascending: false })
-
-      if (casosError) throw casosError
-
-      const hechoVictimCounts: Record<string, number> = {}
-      for (const caso of casosData || []) {
-        if (caso.hecho_id) {
-          hechoVictimCounts[caso.hecho_id] = (hechoVictimCounts[caso.hecho_id] || 0) + 1
-        }
-      }
-
-      const transformedCases: CaseData[] = await Promise.all(
-        (casosData || []).map(async (caso: any) => {
-          const victima = caso.victimas || {}
-          const hecho = caso.hechos || {}
-
-          const { data: seguimientoData, error: segError } = await supabase
-            .from("seguimiento")
-            .select("lista_contactos_familiares")
-            .eq("hecho_id", caso.hecho_id)
-            .order("created_at", { ascending: true })
-            .limit(1)
-            .maybeSingle()
-
-          if (segError && segError.code !== "PGRST116") {
-            console.log("[v0] Error fetching seguimiento:", segError)
-          }
-
-          let familyContactName = "No especificado"
-          let familyRelationship = "Familiar"
-          let familyContactPhone = "No especificado"
-
-          if (seguimientoData?.lista_contactos_familiares) {
-            const contactos = seguimientoData.lista_contactos_familiares as any[]
-            if (contactos && contactos.length > 0) {
-              const primerContacto = contactos[0]
-              familyContactName = primerContacto.nombre || "No especificado"
-              familyRelationship = primerContacto.parentesco || "Familiar"
-              const telefono = primerContacto.telefono
-              familyContactPhone = telefono && telefono.trim() !== "" ? telefono : "No especificado"
-            }
-          }
-
-          return {
-            id: caso.id,
-            victimName: victima.nombre_completo || "Sin nombre",
-            incidentDate: hecho.fecha_hecho || new Date().toISOString(),
-            location: hecho.municipio || hecho.provincia || "No especificado",
-            province: hecho.provincia || "No especificado",
-            status:
-              caso.estado && caso.estado.trim() !== ""
-                ? caso.estado
-                : caso.estado_general && caso.estado_general.trim() !== ""
-                  ? caso.estado_general
-                  : "En investigación",
-            familyContactName,
-            familyRelationship,
-            familyContactPhone,
-            hechoId: caso.hecho_id,
-            totalVictimsInHecho: caso.hecho_id ? hechoVictimCounts[caso.hecho_id] : 1,
-          }
-        }),
-      )
-
-      setCases(transformedCases)
+      const data = await fetchCasesList(supabase)
+      setCases(data)
     } catch (err) {
       console.error("Error fetching cases:", err)
       setError("Error al cargar los casos")
@@ -166,6 +69,9 @@ export function CasesGrid({ filters = {} }: CasesGridProps) {
       setIsLoading(false)
     }
   }
+
+  const displayLocation = (c: CaseListItem) =>
+    c.municipio !== "No especificado" ? c.municipio : c.provincia
 
   const filteredCases = cases.filter((case_) => {
     // Date range filter
@@ -182,12 +88,12 @@ export function CasesGrid({ filters = {} }: CasesGridProps) {
     }
 
     // Province filter
-    if (filters.province && case_.province !== filters.province) {
+    if (filters.province && case_.provincia !== filters.province) {
       return false
     }
 
     // Location filter (partial match)
-    if (filters.location && !case_.location.toLowerCase().includes(filters.location.toLowerCase())) {
+    if (filters.location && !displayLocation(case_).toLowerCase().includes(filters.location.toLowerCase())) {
       return false
     }
 
@@ -210,7 +116,7 @@ export function CasesGrid({ filters = {} }: CasesGridProps) {
     if (filters.searchTerm) {
       const searchLower = filters.searchTerm.toLowerCase()
       const matchesName = case_.victimName.toLowerCase().includes(searchLower)
-      const matchesLocation = case_.location.toLowerCase().includes(searchLower)
+      const matchesLocation = displayLocation(case_).toLowerCase().includes(searchLower)
       if (!matchesName && !matchesLocation) {
         return false
       }
@@ -284,13 +190,14 @@ export function CasesGrid({ filters = {} }: CasesGridProps) {
 
                     <div className="flex items-center gap-2">
                       <MapPin className="w-4 h-4 text-slate-400" />
-                      <span className="line-clamp-1">{case_.location}</span>
+                      <span className="line-clamp-1">{displayLocation(case_)}</span>
                     </div>
 
                     <div className="flex items-center gap-2">
                       <User className="w-4 h-4 text-slate-400" />
                       <span className="line-clamp-1">
-                        {case_.familyContactName} - {case_.familyRelationship}
+                        {case_.familyContactName}
+                        {case_.familyRelationship ? ` - ${case_.familyRelationship}` : ""}
                       </span>
                     </div>
 

--- a/components/cases/cases-grid.tsx
+++ b/components/cases/cases-grid.tsx
@@ -1,13 +1,12 @@
 "use client"
 
-import { useState, useEffect } from "react"
 import Link from "next/link"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Calendar, MapPin, User, Search, Loader2, Users } from "lucide-react"
-import { createClient } from "@/lib/supabase/client"
 import { formatDateUTC } from "@/lib/utils"
-import { fetchCasesList, type CaseListItem } from "@/lib/data/casos"
+import { type CaseListItem } from "@/lib/data/casos"
+import { useCasesList } from "@/lib/queries/casos"
 
 const getStatusColor = (status: string) => {
   switch (status) {
@@ -47,28 +46,7 @@ interface CasesGridProps {
 }
 
 export function CasesGrid({ filters = {} }: CasesGridProps) {
-  const [cases, setCases] = useState<CaseListItem[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const supabase = createClient()
-
-  useEffect(() => {
-    fetchCases()
-  }, [])
-
-  const fetchCases = async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
-      const data = await fetchCasesList(supabase)
-      setCases(data)
-    } catch (err) {
-      console.error("Error fetching cases:", err)
-      setError("Error al cargar los casos")
-    } finally {
-      setIsLoading(false)
-    }
-  }
+  const { data: cases = [], isLoading, error, refetch } = useCasesList()
 
   const displayLocation = (c: CaseListItem) =>
     c.municipio !== "No especificado" ? c.municipio : c.provincia
@@ -139,8 +117,8 @@ export function CasesGrid({ filters = {} }: CasesGridProps) {
       <div className="text-center py-12">
         <Search className="w-12 h-12 text-red-400 mx-auto mb-4" />
         <h3 className="text-lg font-medium text-slate-900 mb-2">Error al cargar casos</h3>
-        <p className="text-slate-600 mb-4">{error}</p>
-        <button onClick={fetchCases} className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+        <p className="text-slate-600 mb-4">Error al cargar los casos</p>
+        <button onClick={() => refetch()} className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
           Reintentar
         </button>
       </div>

--- a/components/dashboard/argentina-map.tsx
+++ b/components/dashboard/argentina-map.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge"
 import { Loader2 } from "lucide-react"
 import { createClient } from "@/lib/supabase/client"
+import { fetchDashboardStats } from "@/lib/data/dashboard"
 
 interface ProvinceData {
   province: string
@@ -69,29 +70,15 @@ export function ArgentinaMap() {
     try {
       setIsLoading(true)
       setError(null)
-
-      const { data, error: fetchError } = await supabase.from("hechos").select("provincia")
-
-      if (fetchError) throw fetchError
-
-      // Count cases by province
-      const provinceCounts: Record<string, number> = {}
-      data.forEach((incident: any) => {
-        if (incident.provincia) {
-          provinceCounts[incident.provincia] = (provinceCounts[incident.provincia] || 0) + 1
-        }
-      })
-
-      // Transform to component format
-      const locations: ProvinceData[] = Object.entries(provinceCounts)
-        .map(([province, cases]) => ({
-          province,
-          cases,
-          coordinates: provinceCoordinates[province] || { x: 50, y: 50 },
-        }))
-        .sort((a, b) => b.cases - a.cases)
-
-      setCaseLocations(locations)
+      const stats = await fetchDashboardStats(supabase)
+      // La RPC ya devuelve los agregados ordenados; sólo agregamos coords.
+      setCaseLocations(
+        stats.casesByProvince.map((p) => ({
+          province: p.provincia,
+          cases: p.cases,
+          coordinates: provinceCoordinates[p.provincia] || { x: 50, y: 50 },
+        })),
+      )
     } catch (err) {
       console.error("Error fetching case locations:", err)
       setError("Error al cargar la distribución de casos")

--- a/components/dashboard/argentina-map.tsx
+++ b/components/dashboard/argentina-map.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useMemo } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Loader2 } from "lucide-react"
-import { createClient } from "@/lib/supabase/client"
-import { fetchDashboardStats } from "@/lib/data/dashboard"
+import { useDashboardStats } from "@/lib/queries/dashboard"
 
 interface ProvinceData {
   province: string
@@ -57,35 +56,18 @@ const getPointColor = (cases: number) => {
 }
 
 export function ArgentinaMap() {
-  const [caseLocations, setCaseLocations] = useState<ProvinceData[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const supabase = createClient()
-
-  useEffect(() => {
-    fetchCasesByProvince()
-  }, [])
-
-  const fetchCasesByProvince = async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
-      const stats = await fetchDashboardStats(supabase)
-      // La RPC ya devuelve los agregados ordenados; sólo agregamos coords.
-      setCaseLocations(
-        stats.casesByProvince.map((p) => ({
-          province: p.provincia,
-          cases: p.cases,
-          coordinates: provinceCoordinates[p.provincia] || { x: 50, y: 50 },
-        })),
-      )
-    } catch (err) {
-      console.error("Error fetching case locations:", err)
-      setError("Error al cargar la distribución de casos")
-    } finally {
-      setIsLoading(false)
-    }
-  }
+  const { data: stats, isLoading, error, refetch } = useDashboardStats()
+  // La RPC ya devuelve los agregados ordenados por casos desc; sólo
+  // adjuntamos las coordenadas hardcoded de cada provincia.
+  const caseLocations = useMemo<ProvinceData[]>(
+    () =>
+      (stats?.casesByProvince ?? []).map((p) => ({
+        province: p.provincia,
+        cases: p.cases,
+        coordinates: provinceCoordinates[p.provincia] || { x: 50, y: 50 },
+      })),
+    [stats],
+  )
 
   if (isLoading) {
     return (
@@ -113,9 +95,9 @@ export function ArgentinaMap() {
         </CardHeader>
         <CardContent>
           <div className="text-center py-12">
-            <p className="text-slate-600 mb-4">{error}</p>
+            <p className="text-slate-600 mb-4">Error al cargar la distribución de casos</p>
             <button
-              onClick={fetchCasesByProvince}
+              onClick={() => refetch()}
               className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
             >
               Reintentar

--- a/components/dashboard/cases-by-year-chart.tsx
+++ b/components/dashboard/cases-by-year-chart.tsx
@@ -3,9 +3,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
 import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from "recharts"
-import { createClient } from "@/lib/supabase/client"
-import { useEffect, useState } from "react"
-import { fetchDashboardStats, type YearlyData } from "@/lib/data/dashboard"
+import { useDashboardStats } from "@/lib/queries/dashboard"
 
 const chartConfig = {
   cases: {
@@ -15,23 +13,8 @@ const chartConfig = {
 }
 
 export function CasesByYearChart() {
-  const [data, setData] = useState<YearlyData[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const fetchYearlyData = async () => {
-      try {
-        const stats = await fetchDashboardStats(createClient())
-        setData(stats.casesByYear)
-      } catch (error) {
-        console.error("Error fetching yearly data:", error)
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchYearlyData()
-  }, [])
+  const { data: stats, isLoading: loading } = useDashboardStats()
+  const data = stats?.casesByYear ?? []
 
   if (loading) {
     return (

--- a/components/dashboard/cases-by-year-chart.tsx
+++ b/components/dashboard/cases-by-year-chart.tsx
@@ -5,11 +5,7 @@ import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/
 import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis } from "recharts"
 import { createClient } from "@/lib/supabase/client"
 import { useEffect, useState } from "react"
-
-interface YearlyData {
-  year: string
-  cases: number
-}
+import { fetchDashboardStats, type YearlyData } from "@/lib/data/dashboard"
 
 const chartConfig = {
   cases: {
@@ -25,29 +21,8 @@ export function CasesByYearChart() {
   useEffect(() => {
     const fetchYearlyData = async () => {
       try {
-        const supabase = createClient()
-
-        const { data: hechos, error } = await supabase.from("hechos").select("fecha_hecho")
-
-        if (error) {
-          console.error("Error fetching yearly data:", error)
-          return
-        }
-
-        const yearCounts: { [key: string]: number } = {}
-
-        hechos?.forEach((hecho) => {
-          if (hecho.fecha_hecho) {
-            const year = new Date(hecho.fecha_hecho).getFullYear().toString()
-            yearCounts[year] = (yearCounts[year] || 0) + 1
-          }
-        })
-
-        const chartData = Object.entries(yearCounts)
-          .map(([year, cases]) => ({ year, cases }))
-          .sort((a, b) => Number.parseInt(a.year) - Number.parseInt(b.year))
-
-        setData(chartData)
+        const stats = await fetchDashboardStats(createClient())
+        setData(stats.casesByYear)
       } catch (error) {
         console.error("Error fetching yearly data:", error)
       } finally {

--- a/components/dashboard/dashboard-stats.tsx
+++ b/components/dashboard/dashboard-stats.tsx
@@ -1,34 +1,12 @@
 "use client"
 
-import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { AlertTriangle, FileText, Calendar, Scale, Loader2 } from "lucide-react"
-import { createClient } from "@/lib/supabase/client"
-import { fetchDashboardStats, type DashboardKPIs } from "@/lib/data/dashboard"
+import { useDashboardStats } from "@/lib/queries/dashboard"
 
 export function DashboardStats() {
-  const [stats, setStats] = useState<DashboardKPIs | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const supabase = createClient()
-
-  useEffect(() => {
-    fetchStats()
-  }, [])
-
-  const fetchStats = async () => {
-    try {
-      setIsLoading(true)
-      setError(null)
-      const data = await fetchDashboardStats(supabase)
-      setStats(data.kpis)
-    } catch (err) {
-      console.error("Error fetching stats:", err)
-      setError("Error al cargar estadísticas")
-    } finally {
-      setIsLoading(false)
-    }
-  }
+  const { data, isLoading, error, refetch } = useDashboardStats()
+  const stats = data?.kpis ?? null
 
   if (isLoading) {
     return (
@@ -50,9 +28,13 @@ export function DashboardStats() {
         <Card className="border-slate-200 col-span-full">
           <CardContent className="flex items-center justify-center h-32">
             <div className="text-center">
-              <p className="text-slate-600 mb-2">{error || "No se pudieron cargar las estadísticas"}</p>
+              <p className="text-slate-600 mb-2">
+                {error instanceof Error
+                  ? "Error al cargar estadísticas"
+                  : "No se pudieron cargar las estadísticas"}
+              </p>
               <button
-                onClick={fetchStats}
+                onClick={() => refetch()}
                 className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm"
               >
                 Reintentar

--- a/components/dashboard/dashboard-stats.tsx
+++ b/components/dashboard/dashboard-stats.tsx
@@ -4,16 +4,10 @@ import { useState, useEffect } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { AlertTriangle, FileText, Calendar, Scale, Loader2 } from "lucide-react"
 import { createClient } from "@/lib/supabase/client"
-
-interface StatsData {
-  totalCases: number
-  casesLastYear: number
-  casesWithoutConviction: number
-  casesInInvestigation: number
-}
+import { fetchDashboardStats, type DashboardKPIs } from "@/lib/data/dashboard"
 
 export function DashboardStats() {
-  const [stats, setStats] = useState<StatsData | null>(null)
+  const [stats, setStats] = useState<DashboardKPIs | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const supabase = createClient()
@@ -26,46 +20,8 @@ export function DashboardStats() {
     try {
       setIsLoading(true)
       setError(null)
-
-      const { data: victimas, error: victimasError } = await supabase.from("victimas").select(`
-          id,
-          created_at,
-          hechos (
-            id,
-            fecha_hecho
-          )
-        `)
-
-      if (victimasError) throw victimasError
-
-      const { data: imputados, error: imputadosError } = await supabase.from("imputados").select(`
-          id,
-          estado_procesal,
-          hechos!inner (
-            victima_id
-          )
-        `)
-
-      if (imputadosError) throw imputadosError
-
-      const totalCases = victimas?.length || 0
-
-      const oneYearAgo = new Date()
-      oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
-      const casesLastYear = victimas?.filter((victim) => new Date(victim.created_at) >= oneYearAgo).length || 0
-
-      const casesWithoutConviction =
-        imputados?.filter((imputado) => imputado.estado_procesal !== "Condenado").length || 0
-
-      const casesInInvestigation =
-        imputados?.filter((imputado) => imputado.estado_procesal === "En investigación").length || 0
-
-      setStats({
-        totalCases,
-        casesLastYear,
-        casesWithoutConviction,
-        casesInInvestigation,
-      })
+      const data = await fetchDashboardStats(supabase)
+      setStats(data.kpis)
     } catch (err) {
       console.error("Error fetching stats:", err)
       setError("Error al cargar estadísticas")

--- a/components/dashboard/status-distribution-chart.tsx
+++ b/components/dashboard/status-distribution-chart.tsx
@@ -5,6 +5,7 @@ import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/
 import { Cell, Pie, PieChart, ResponsiveContainer } from "recharts"
 import { createClient } from "@/lib/supabase/client"
 import { useEffect, useState } from "react"
+import { fetchDashboardStats } from "@/lib/data/dashboard"
 
 interface StatusData {
   status: string
@@ -63,29 +64,14 @@ export function StatusDistributionChart() {
   useEffect(() => {
     const fetchStatusData = async () => {
       try {
-        const supabase = createClient()
-
-        const { data: imputados, error } = await supabase.from("imputados").select("estado_procesal")
-
-        if (error) {
-          console.error("Error fetching status data:", error)
-          return
-        }
-
-        const statusCounts: { [key: string]: number } = {}
-
-        imputados?.forEach((imputado) => {
-          const status = imputado.estado_procesal || "Otros"
-          statusCounts[status] = (statusCounts[status] || 0) + 1
-        })
-
-        const chartData = Object.entries(statusCounts).map(([status, cases]) => ({
-          status,
-          cases,
-          fill: statusColors[status] || statusColors["Otros"],
-        }))
-
-        setData(chartData)
+        const stats = await fetchDashboardStats(createClient())
+        setData(
+          stats.casesByStatus.map((s) => ({
+            status: s.status,
+            cases: s.cases,
+            fill: statusColors[s.status] || statusColors["Otros"],
+          })),
+        )
       } catch (error) {
         console.error("Error fetching status data:", error)
       } finally {

--- a/components/dashboard/status-distribution-chart.tsx
+++ b/components/dashboard/status-distribution-chart.tsx
@@ -3,9 +3,8 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
 import { Cell, Pie, PieChart, ResponsiveContainer } from "recharts"
-import { createClient } from "@/lib/supabase/client"
-import { useEffect, useState } from "react"
-import { fetchDashboardStats } from "@/lib/data/dashboard"
+import { useMemo } from "react"
+import { useDashboardStats } from "@/lib/queries/dashboard"
 
 interface StatusData {
   status: string
@@ -58,29 +57,16 @@ const statusColors: { [key: string]: string } = {
 }
 
 export function StatusDistributionChart() {
-  const [data, setData] = useState<StatusData[]>([])
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    const fetchStatusData = async () => {
-      try {
-        const stats = await fetchDashboardStats(createClient())
-        setData(
-          stats.casesByStatus.map((s) => ({
-            status: s.status,
-            cases: s.cases,
-            fill: statusColors[s.status] || statusColors["Otros"],
-          })),
-        )
-      } catch (error) {
-        console.error("Error fetching status data:", error)
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchStatusData()
-  }, [])
+  const { data: stats, isLoading: loading } = useDashboardStats()
+  const data = useMemo<StatusData[]>(
+    () =>
+      (stats?.casesByStatus ?? []).map((s) => ({
+        status: s.status,
+        cases: s.cases,
+        fill: statusColors[s.status] || statusColors["Otros"],
+      })),
+    [stats],
+  )
 
   if (loading) {
     return (

--- a/components/providers/query-provider.tsx
+++ b/components/providers/query-provider.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+// Provider de TanStack Query para toda la app.
+//
+// Defaults pensados para una BD chica que cambia poco:
+//   staleTime: 5 min   -> navegar ida y vuelta no re-fetchea
+//   gcTime:    10 min  -> data fuera de pantalla queda en RAM
+//   refetchOnWindowFocus: false -> no traer todo de nuevo al volver al tab
+//
+// Las invalidaciones explícitas (cuando se crea/edita/elimina un caso)
+// están en los mutation sites de `case-form.tsx` y `case-detail-content.tsx`.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { useState, type ReactNode } from "react"
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  // useState garantiza una sola instancia por mount (no reasignar en re-render).
+  const [client] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 5 * 60 * 1000,
+            gcTime: 10 * 60 * 1000,
+            refetchOnWindowFocus: false,
+            retry: 1,
+          },
+        },
+      }),
+  )
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}

--- a/components/ui/file-upload.tsx
+++ b/components/ui/file-upload.tsx
@@ -57,27 +57,17 @@ export function FileUpload({
 
       const supabase = createClient()
 
-      // Debug: Check if user is authenticated
       const {
         data: { session },
-        error: sessionError,
       } = await supabase.auth.getSession()
-      console.log("[v0] FileUpload - Session check:", {
-        hasSession: !!session,
-        userId: session?.user?.id,
-        sessionError: sessionError?.message,
-      })
 
       if (!session) {
-        console.log("[v0] FileUpload - No session found, upload will likely fail")
         setError("No hay sesión activa. Por favor, inicia sesión nuevamente.")
         setIsUploading(false)
         return
       }
 
-      console.log("[v0] FileUpload - Attempting upload with authenticated client")
       const result = await uploadFile(supabase, file, folder)
-      console.log("[v0] FileUpload - Upload result:", result)
 
       if (result.success && result.path && result.url) {
         onUpload({

--- a/docs/performance-audit.md
+++ b/docs/performance-audit.md
@@ -1,0 +1,211 @@
+# Auditoría de performance — BD Usina
+
+Fecha: 2026-06-09 · Rama: `claude/performance-audit`
+
+Alcance: indexes, cache, payloads y rendering de la app Next.js 15 + Supabase.
+Este documento identifica los cuellos de botella actuales y propone un plan de
+implementación. **No incluye cambios de código** (solo análisis y plan).
+
+---
+
+## 1. Cuellos de botella principales (ordenados por impacto)
+
+### 1.1 🔴 N+1 queries en los listados de casos
+
+Archivos: `app/casos/page.tsx`, `components/cases/cases-grid.tsx`,
+`components/cases/animated-cases-grid.tsx` (la misma lógica está duplicada 3 veces).
+
+El patrón actual:
+
+1. Trae **todos** los casos (`select ... order by created_at`, sin `limit`).
+2. Por **cada caso** dispara una query individual a `seguimiento`
+   (`.eq("hecho_id", ...).limit(1).maybeSingle()`).
+
+Con N casos son **N+1 requests HTTP** desde el browser a Supabase. Con 200
+casos: 201 round-trips (~50-150 ms c/u desde Argentina a us-east). Es la causa
+dominante del tiempo de carga de la home y de `/casos`.
+
+Agravante: la home monta `AnimatedCasesGrid` por defecto, así que este costo se
+paga en la primera pantalla que ve todo usuario.
+
+### 1.2 🔴 Cascada secuencial en el detalle de caso
+
+Archivo: `components/cases/case-detail-content.tsx` (`loadFullCaseData`).
+
+La carga de un caso encadena ~8-12 queries **secuenciales** (víctima → hecho →
+imputados → instancias por imputado (N+1) → seguimiento → recursos del hecho →
+recursos de la víctima → recursos por imputado (N+1) → hermanos de hecho).
+Cada `await` espera al anterior aunque la mayoría son independientes.
+
+### 1.3 🔴 Todo es client-side rendering sin cache
+
+Todas las páginas con datos son `"use client"` + `useEffect` + fetch desde el
+browser. Consecuencias:
+
+- **Cascada de arranque**: middleware → HTML vacío → descarga JS → `AuthGuard`
+  resuelve sesión (spinner bloqueante en `components/auth/auth-guard.tsx`) →
+  recién ahí empiezan los fetch de datos → N+1.
+- **Cero cache**: no hay `revalidate`, ni cache de datos, ni SWR/React Query.
+  Cada navegación re-fetchea todo desde cero (ir a un caso y volver al listado
+  vuelve a disparar las 200+ queries).
+- Next 15 App Router está usado solo como router; no se aprovecha ni Server
+  Components ni el data cache.
+
+### 1.4 🟡 Middleware: 2 round-trips a Supabase por navegación
+
+Archivo: `lib/supabase/middleware.ts`.
+
+En **cada request** (matcher cubre casi todo) hace `auth.getUser()` (llamada de
+red al endpoint de Auth) **más** una query a `allowed_users`. Son ~100-300 ms
+agregados a cada navegación, antes de servir un solo byte de página. La
+whitelist no se cachea de ninguna forma. Encima `AuthGuard` repite el chequeo
+de sesión en el cliente (doble validación).
+
+### 1.5 🟡 Dashboard: trae filas enteras para contar
+
+Archivos: `components/dashboard/*.tsx`.
+
+Las 4 secciones traen **todas las filas** y cuentan/agrupan en JS:
+`dashboard-stats` baja todas las víctimas + todos los imputados; el chart por
+año baja todos los `fecha_hecho`; el mapa todas las `provincia`; el de estados
+todos los `estado_procesal`. El payload crece linealmente con la BD cuando
+la respuesta correcta son agregaciones (`count`, `group by`) que devuelven
+bytes. Además son 5 queries paralelas no compartidas (stats pide lo mismo que
+los charts).
+
+### 1.6 🟡 Payloads con `select("*")` y JSON pesado
+
+- `case-detail-content.tsx` usa `select("*")` en victimas, hechos, imputados,
+  seguimiento y recursos — incluye campos largos (notas, resúmenes, arrays
+  JSON de contactos/abogados) aunque la vista no los muestre todos.
+- Los listados piden `lista_contactos_familiares` (JSON) completo por fila
+  para mostrar solo nombre/parentesco/teléfono del primer contacto.
+
+### 1.7 🟡 Rendering: vista animada triplica el DOM
+
+`components/cases/animated-cases-grid.tsx` duplica el dataset ×3
+(`[...cases, ...cases, ...cases]`) para el efecto marquee y anima con
+`hover:scale-105` + sombras. Con 200 casos son **600 cards** montadas y
+animadas en la home. Costo alto de layout/paint, especialmente en máquinas
+modestas. No hay virtualización.
+
+### 1.8 🟢 Menores
+
+- ~20 `console.log` en hot paths (uno por caso por render de listado;
+  serializan objetos grandes).
+- `recharts` (~100 KB gz) entra en el bundle del dashboard sin import dinámico.
+- `next.config.mjs`: `images.unoptimized: true` (sin optimización de imágenes)
+  e `ignoreBuildErrors: true` (deuda, no perf).
+- Filtrado y paginación 100% en cliente: correcto mientras la tabla sea chica,
+  pero ya hoy obliga a bajar todo para mostrar 12.
+
+### 1.9 Indexes (estado actual: razonable)
+
+`scripts/001_create_tables.sql` ya crea indexes en todas las FKs usadas
+(`hechos.victima_id`, `imputados.hecho_id`, `seguimiento.hecho_id`,
+`recursos.hecho_id/imputado_id`, `casos.victima_id/hecho_id`). Faltantes
+detectados (impacto bajo con volúmenes actuales, conviene dejarlos listos):
+
+| Index faltante | Query que lo usa |
+|---|---|
+| `casos(created_at desc)` | `order by created_at` en todos los listados |
+| `recursos(victima_id)` | recursos por víctima en detalle de caso (columna agregada post-schema, sin index) |
+| `instancias_judiciales(imputado_id)` | instancias por imputado en detalle |
+| `allowed_users(email)` (unique) | chequeo de whitelist en **cada request** del middleware |
+
+> Nota: con cientos/miles de filas, Postgres resuelve esto rápido incluso sin
+> index. El problema dominante NO son los indexes sino la cantidad de
+> round-trips (1.1–1.4).
+
+---
+
+## 2. Plan de implementación propuesto
+
+Ordenado por relación impacto/esfuerzo. Cada fase es deployable por separado.
+
+### Fase 1 — Eliminar los N+1 (impacto: alto, esfuerzo: bajo)
+
+1. **Listados**: reemplazar el loop de queries a `seguimiento` por un único
+   fetch embebido en la query principal de PostgREST:
+   `casos.select("..., hechos(..., seguimiento(lista_contactos_familiares))")`,
+   o un segundo fetch batch con `.in("hecho_id", [...])`. Resultado: de N+1
+   requests a 1-2.
+2. **Detalle de caso**: paralelizar las queries independientes con
+   `Promise.all` y embeber `instancias_judiciales(*)` en la query de imputados
+   y los 3 tipos de recursos en una sola query con `.or(...)`. Resultado: de
+   ~8-12 round-trips secuenciales a 2-3 paralelos.
+3. **Unificar la lógica duplicada** de los 3 listados en un hook/función
+   compartida (`lib/data/casos.ts`) para no arreglar lo mismo 3 veces.
+4. Borrar los `console.log` de hot paths.
+
+### Fase 2 — Agregaciones en el dashboard (impacto: alto, esfuerzo: bajo)
+
+1. Crear una función RPC en Postgres (`get_dashboard_stats()`) o una vista que
+   devuelva los conteos ya agregados (total, último año, sin condena, en
+   investigación, casos por año, por provincia, por estado procesal).
+2. El dashboard pasa de 5 queries que bajan tablas enteras a **1 RPC** que
+   devuelve ~1 KB.
+3. Import dinámico de `recharts` (`next/dynamic`) para sacarlo del bundle
+   inicial del dashboard.
+
+### Fase 3 — Cache y data-fetching moderno (impacto: alto, esfuerzo: medio)
+
+1. Introducir **TanStack Query (React Query)** como capa de cache cliente:
+   - `staleTime` de 1-5 min para listados y dashboard: navegar ida y vuelta
+     deja de re-fetchear todo.
+   - Invalidation al crear/editar casos.
+   - Reemplaza los `useState`+`useEffect` manuales (menos código, menos bugs).
+2. Alternativa más profunda (opcional, evaluar después de 3.1): migrar
+   listados y detalle a **Server Components** con fetch en servidor +
+   `revalidate`. Mayor reescritura; conviene decidirlo con métricas de la
+   Fase 1-2 en mano.
+
+### Fase 4 — Middleware y auth (impacto: medio, esfuerzo: bajo)
+
+1. Cachear el resultado de la whitelist en una **cookie firmada o claim JWT**
+   (app_metadata) con TTL corto (ej. 15 min), para no pegar a `allowed_users`
+   en cada request. Alternativa simple: solo consultar whitelist en `/login` y
+   en rutas de mutación.
+2. Index/unique en `allowed_users(email)`.
+3. Eliminar el doble chequeo de `AuthGuard` en cliente (el middleware ya
+   garantiza sesión); dejar solo el listener de `SIGNED_OUT`. Esto saca el
+   spinner bloqueante del primer render.
+
+### Fase 5 — Indexes y payloads (impacto: bajo hoy, blindaje a futuro)
+
+1. Migración SQL con los 4 indexes faltantes de la tabla de §1.9.
+2. Reemplazar `select("*")` por listas de columnas en el detalle de caso.
+3. Paginación real en servidor (`.range()`) en `/casos` cuando el volumen lo
+   justifique (>500 casos), junto con filtros server-side.
+
+### Fase 6 — Rendering (impacto: medio en máquinas lentas)
+
+1. Vista animada: limitar a los ~20-30 casos más recientes (es una vitrina,
+   no necesita el dataset completo), con CSS `will-change: transform` y
+   `content-visibility: auto` en las cards fuera de viewport.
+2. Evaluar virtualización (`@tanstack/react-virtual`) en `/casos` si se
+   abandona la paginación.
+3. Activar optimización de imágenes de Next (`images.unoptimized: false`) si
+   se empiezan a servir fotos/recursos visuales.
+
+### Métricas para validar (antes/después de cada fase)
+
+- Requests a Supabase por carga de página (Network tab): hoy home ≈ N+1.
+  Objetivo Fase 1: ≤ 3.
+- LCP y TTI de home, `/casos`, `/dashboard` y detalle (Lighthouse).
+- Payload transferido por página (KB).
+
+---
+
+## 3. Resumen ejecutivo
+
+| # | Cuello de botella | Severidad | Fix | Fase |
+|---|---|---|---|---|
+| 1 | N+1 de seguimiento en listados (×3 componentes) | 🔴 | Embed/batch query | 1 |
+| 2 | Cascada secuencial en detalle de caso | 🔴 | Promise.all + embeds | 1 |
+| 3 | CSR puro sin cache, re-fetch en cada navegación | 🔴 | React Query (→ RSC) | 3 |
+| 4 | Middleware: 2 round-trips por request | 🟡 | Cache de whitelist | 4 |
+| 5 | Dashboard baja tablas enteras para contar | 🟡 | RPC agregada | 2 |
+| 6 | `select("*")` y JSON pesado en payloads | 🟡 | Columnas explícitas | 5 |
+| 7 | Vista animada triplica DOM (600 cards) | 🟡 | Limitar dataset | 6 |
+| 8 | Indexes faltantes (created_at, allowed_users, etc.) | 🟢 | Migración SQL | 5 |

--- a/lib/auth/whitelist-cookie.ts
+++ b/lib/auth/whitelist-cookie.ts
@@ -1,0 +1,94 @@
+// Cookie firmada (HMAC-SHA256) que cachea el chequeo de whitelist del
+// middleware. Sin esto, cada request autenticado pega a `allowed_users`
+// además de a `auth.getUser()`. Con esto, mientras la cookie sea válida
+// (15 min) y el email matchee, no hay query a la BD.
+//
+// El secret se pasa por env var `WHITELIST_COOKIE_SECRET`. Si no está
+// seteado, el cacheo se deshabilita silenciosamente y se hace fallback
+// a la query directa (sin regresión funcional, sólo sin la mejora).
+//
+// Edge Runtime compatible: usa Web Crypto API (`crypto.subtle`).
+
+export const WHITELIST_COOKIE_NAME = "usina_wl"
+
+const TTL_MS = 15 * 60 * 1000
+const encoder = new TextEncoder()
+
+function base64UrlEncode(bytes: Uint8Array | string): string {
+  const raw =
+    typeof bytes === "string"
+      ? bytes
+      : String.fromCharCode(...bytes)
+  return btoa(raw).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "")
+}
+
+function base64UrlDecodeToBytes(s: string): Uint8Array {
+  const padded = s.replace(/-/g, "+").replace(/_/g, "/")
+    .padEnd(Math.ceil(s.length / 4) * 4, "=")
+  return Uint8Array.from(atob(padded), (c) => c.charCodeAt(0))
+}
+
+async function importKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  )
+}
+
+/** Firma `${email}|${expiryMs}` y devuelve `${b64payload}.${b64sig}`. */
+export async function makeWhitelistCookie(
+  email: string,
+  secret: string,
+): Promise<string> {
+  const expiry = Date.now() + TTL_MS
+  const payload = `${email}|${expiry}`
+  const key = await importKey(secret)
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload))
+  return `${base64UrlEncode(payload)}.${base64UrlEncode(new Uint8Array(sig))}`
+}
+
+/** Devuelve true sólo si la cookie es válida, no expiró y el email coincide. */
+export async function verifyWhitelistCookie(
+  cookie: string | undefined,
+  email: string,
+  secret: string,
+): Promise<boolean> {
+  if (!cookie) return false
+  const dot = cookie.indexOf(".")
+  if (dot < 0) return false
+  const payloadB64 = cookie.slice(0, dot)
+  const sigB64 = cookie.slice(dot + 1)
+
+  let payload: string
+  let sigBytes: Uint8Array
+  try {
+    payload = new TextDecoder().decode(base64UrlDecodeToBytes(payloadB64))
+    sigBytes = base64UrlDecodeToBytes(sigB64)
+  } catch {
+    return false
+  }
+
+  const key = await importKey(secret)
+  const ok = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    sigBytes,
+    encoder.encode(payload),
+  )
+  if (!ok) return false
+
+  const sep = payload.indexOf("|")
+  if (sep < 0) return false
+  const cookieEmail = payload.slice(0, sep)
+  const expiryStr = payload.slice(sep + 1)
+  if (cookieEmail !== email) return false
+  const expiry = Number(expiryStr)
+  if (!Number.isFinite(expiry) || expiry < Date.now()) return false
+
+  return true
+}
+
+export const WHITELIST_COOKIE_MAX_AGE_SECONDS = Math.floor(TTL_MS / 1000)

--- a/lib/data/casos.ts
+++ b/lib/data/casos.ts
@@ -1,0 +1,110 @@
+// Data layer para los listados de casos.
+//
+// Centraliza la query que arma cada "tarjeta" de caso para `/`, `/casos` y
+// la vista animada. Antes cada componente disparaba N+1 queries (una a `casos`
+// + una a `seguimiento` por cada caso); ahora es una sola query con embeds.
+
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+export interface CaseListItem {
+  id: string
+  victimName: string
+  incidentDate: string
+  municipio: string
+  provincia: string
+  status: string
+  familyContactName: string
+  familyRelationship: string
+  familyContactPhone: string
+  hechoId: string
+  totalVictimsInHecho: number
+}
+
+const NOT_SPECIFIED = "No especificado"
+const DEFAULT_STATUS = "En investigación"
+
+interface ContactoFamiliarMin {
+  nombre?: string | null
+  parentesco?: string | null
+  telefono?: string | null
+}
+
+interface SeguimientoMin {
+  lista_contactos_familiares: ContactoFamiliarMin[] | null
+  created_at: string | null
+}
+
+/**
+ * Trae todos los casos con la info necesaria para los listados, en una sola
+ * query embebida. La transformación a `CaseListItem` se hace en JS (no en
+ * SQL) para mantener compatible la lógica con los componentes existentes.
+ */
+export async function fetchCasesList(
+  supabase: SupabaseClient,
+): Promise<CaseListItem[]> {
+  const { data: casos, error } = await supabase
+    .from("casos")
+    .select(`
+      id,
+      estado_general,
+      estado,
+      hecho_id,
+      victima_id,
+      created_at,
+      victimas (id, nombre_completo),
+      hechos (
+        id,
+        fecha_hecho,
+        municipio,
+        provincia,
+        seguimiento (lista_contactos_familiares, created_at)
+      )
+    `)
+    .order("created_at", { ascending: false })
+
+  if (error) throw error
+
+  // Cantidad de víctimas por hecho — para el badge "N víctimas".
+  const hechoVictimCounts: Record<string, number> = {}
+  for (const c of (casos ?? []) as any[]) {
+    if (c.hecho_id) {
+      hechoVictimCounts[c.hecho_id] = (hechoVictimCounts[c.hecho_id] ?? 0) + 1
+    }
+  }
+
+  return ((casos ?? []) as any[]).map((c): CaseListItem => {
+    const victima = c.victimas ?? {}
+    const hecho = c.hechos ?? {}
+
+    // El componente original tomaba el seguimiento más viejo
+    // (`order created_at asc limit 1`). Lo replicamos en memoria.
+    const seguimientos: SeguimientoMin[] = hecho.seguimiento ?? []
+    const seguimientoMasViejo = seguimientos
+      .slice()
+      .sort((a, b) => (a.created_at ?? "").localeCompare(b.created_at ?? ""))[0]
+    const primerContacto =
+      seguimientoMasViejo?.lista_contactos_familiares?.[0] ?? null
+
+    const familyContactName = primerContacto?.nombre || NOT_SPECIFIED
+    const familyRelationship = primerContacto?.parentesco || ""
+    const familyContactPhone =
+      primerContacto?.telefono?.trim() || NOT_SPECIFIED
+
+    const status =
+      c.estado?.trim() || c.estado_general?.trim() || DEFAULT_STATUS
+
+    return {
+      id: c.id,
+      victimName: victima.nombre_completo || "Sin nombre",
+      incidentDate: hecho.fecha_hecho || new Date().toISOString(),
+      municipio: hecho.municipio || NOT_SPECIFIED,
+      provincia: hecho.provincia || NOT_SPECIFIED,
+      status,
+      familyContactName,
+      familyRelationship,
+      familyContactPhone,
+      hechoId: c.hecho_id,
+      totalVictimsInHecho: c.hecho_id ? hechoVictimCounts[c.hecho_id] : 1,
+    }
+  })
+}

--- a/lib/data/dashboard.ts
+++ b/lib/data/dashboard.ts
@@ -1,0 +1,67 @@
+// Data layer para el dashboard estadístico.
+//
+// Antes: cada tarjeta/gráfico hacía su propio fetch y traía la tabla
+// entera para contar en JS. Ahora: una sola RPC (`get_dashboard_stats`)
+// devuelve todos los agregados en ~1 KB.
+//
+// Para deduplicar los 4 mounts simultáneos del dashboard se incluye un
+// in-flight share + TTL corto. Cache real (invalidación al editar casos,
+// staleTime configurable, etc.) llega en Fase 3 con React Query.
+
+import type { SupabaseClient } from "@supabase/supabase-js"
+
+export interface DashboardKPIs {
+  totalCases: number
+  casesLastYear: number
+  casesWithoutConviction: number
+  casesInInvestigation: number
+}
+
+export interface YearlyData {
+  year: string
+  cases: number
+}
+
+export interface ProvinceData {
+  provincia: string
+  cases: number
+}
+
+export interface StatusData {
+  status: string
+  cases: number
+}
+
+export interface DashboardStats {
+  kpis: DashboardKPIs
+  casesByYear: YearlyData[]
+  casesByProvince: ProvinceData[]
+  casesByStatus: StatusData[]
+}
+
+const TTL_MS = 30_000
+
+let inFlight: Promise<DashboardStats> | null = null
+let cached: { ts: number; data: DashboardStats } | null = null
+
+export async function fetchDashboardStats(
+  supabase: SupabaseClient,
+): Promise<DashboardStats> {
+  const now = Date.now()
+  if (cached && now - cached.ts < TTL_MS) return cached.data
+  if (inFlight) return inFlight
+
+  inFlight = (async () => {
+    try {
+      const { data, error } = await supabase.rpc("get_dashboard_stats")
+      if (error) throw error
+      const stats = data as DashboardStats
+      cached = { ts: Date.now(), data: stats }
+      return stats
+    } finally {
+      inFlight = null
+    }
+  })()
+
+  return inFlight
+}

--- a/lib/data/dashboard.ts
+++ b/lib/data/dashboard.ts
@@ -1,12 +1,11 @@
 // Data layer para el dashboard estadístico.
 //
-// Antes: cada tarjeta/gráfico hacía su propio fetch y traía la tabla
-// entera para contar en JS. Ahora: una sola RPC (`get_dashboard_stats`)
-// devuelve todos los agregados en ~1 KB.
+// Una sola RPC (`get_dashboard_stats`) devuelve todos los agregados que
+// consume el dashboard en ~1 KB, en lugar de las 5 queries que bajaban
+// tablas enteras y contaban en JS.
 //
-// Para deduplicar los 4 mounts simultáneos del dashboard se incluye un
-// in-flight share + TTL corto. Cache real (invalidación al editar casos,
-// staleTime configurable, etc.) llega en Fase 3 con React Query.
+// El cacheo, dedupe y manejo de stale-while-revalidate los hace React
+// Query a través de `useDashboardStats` (ver `lib/queries/dashboard.ts`).
 
 import type { SupabaseClient } from "@supabase/supabase-js"
 
@@ -39,29 +38,10 @@ export interface DashboardStats {
   casesByStatus: StatusData[]
 }
 
-const TTL_MS = 30_000
-
-let inFlight: Promise<DashboardStats> | null = null
-let cached: { ts: number; data: DashboardStats } | null = null
-
 export async function fetchDashboardStats(
   supabase: SupabaseClient,
 ): Promise<DashboardStats> {
-  const now = Date.now()
-  if (cached && now - cached.ts < TTL_MS) return cached.data
-  if (inFlight) return inFlight
-
-  inFlight = (async () => {
-    try {
-      const { data, error } = await supabase.rpc("get_dashboard_stats")
-      if (error) throw error
-      const stats = data as DashboardStats
-      cached = { ts: Date.now(), data: stats }
-      return stats
-    } finally {
-      inFlight = null
-    }
-  })()
-
-  return inFlight
+  const { data, error } = await supabase.rpc("get_dashboard_stats")
+  if (error) throw error
+  return data as DashboardStats
 }

--- a/lib/queries/casos.ts
+++ b/lib/queries/casos.ts
@@ -1,0 +1,18 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { createClient } from "@/lib/supabase/client"
+import { fetchCasesList, type CaseListItem } from "@/lib/data/casos"
+import { queryKeys } from "@/lib/queries/keys"
+
+/**
+ * Listado de casos cacheado para los 3 componentes (`/`, `/casos`, vista
+ * animada). Comparten la misma queryKey, así que un solo round-trip por
+ * staleTime — la 2da navegación al listado es instantánea.
+ */
+export function useCasesList() {
+  return useQuery<CaseListItem[]>({
+    queryKey: queryKeys.casesList,
+    queryFn: () => fetchCasesList(createClient()),
+  })
+}

--- a/lib/queries/dashboard.ts
+++ b/lib/queries/dashboard.ts
@@ -1,0 +1,18 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { createClient } from "@/lib/supabase/client"
+import { fetchDashboardStats, type DashboardStats } from "@/lib/data/dashboard"
+import { queryKeys } from "@/lib/queries/keys"
+
+/**
+ * KPIs + agregados del dashboard. Una sola RPC compartida por las 4
+ * secciones (cards, chart anual, chart de estado, mapa) — todas
+ * suscriben a la misma queryKey.
+ */
+export function useDashboardStats() {
+  return useQuery<DashboardStats>({
+    queryKey: queryKeys.dashboardStats,
+    queryFn: () => fetchDashboardStats(createClient()),
+  })
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -1,0 +1,6 @@
+// Query keys centralizadas — referenciables desde mutation sites para invalidar.
+
+export const queryKeys = {
+  casesList: ["cases", "list"] as const,
+  dashboardStats: ["dashboard", "stats"] as const,
+} as const

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,5 +1,11 @@
 import { createServerClient } from "@supabase/ssr"
 import { NextResponse, type NextRequest } from "next/server"
+import {
+  WHITELIST_COOKIE_NAME,
+  WHITELIST_COOKIE_MAX_AGE_SECONDS,
+  makeWhitelistCookie,
+  verifyWhitelistCookie,
+} from "@/lib/auth/whitelist-cookie"
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
@@ -39,22 +45,59 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(url)
   }
 
-  if (user && !isPublicRoute) {
-    const { data: allowedUser, error } = await supabase
-      .from("allowed_users")
-      .select("email")
-      .eq("email", user.email)
-      .maybeSingle()
+  // Si ya está logueado y va a /login, mandarlo al home. Antes lo hacía
+  // `AuthGuard` en el cliente con un re-check de sesión; ahora se decide
+  // en el middleware para evitar el doble fetch y el spinner.
+  if (user && request.nextUrl.pathname.startsWith("/login")) {
+    const url = request.nextUrl.clone()
+    url.pathname = "/"
+    return NextResponse.redirect(url)
+  }
 
-    // If user is not in whitelist, redirect to unauthorized page
-    if (error || !allowedUser) {
-      console.log("[v0] User not in whitelist:", user.email)
+  if (user && !isPublicRoute) {
+    const email = user.email
+    if (!email) {
       const url = request.nextUrl.clone()
       url.pathname = "/no-autorizado"
       return NextResponse.redirect(url)
     }
 
-    console.log("[v0] User authorized:", user.email)
+    // Cache hit: cookie firmada con TTL de 15 min. Evita pegarle a
+    // `allowed_users` en cada request.
+    const secret = process.env.WHITELIST_COOKIE_SECRET
+    const cookieValue = request.cookies.get(WHITELIST_COOKIE_NAME)?.value
+    let cacheHit = false
+    if (secret && cookieValue) {
+      cacheHit = await verifyWhitelistCookie(cookieValue, email, secret)
+    }
+
+    if (!cacheHit) {
+      const { data: allowedUser, error } = await supabase
+        .from("allowed_users")
+        .select("email")
+        .eq("email", email)
+        .maybeSingle()
+
+      if (error || !allowedUser) {
+        console.log("[v0] User not in whitelist:", email)
+        const url = request.nextUrl.clone()
+        url.pathname = "/no-autorizado"
+        return NextResponse.redirect(url)
+      }
+
+      // Refrescar la cookie sólo si hay secret configurado. Sin secret,
+      // la mejora queda desactivada pero el flujo sigue funcionando.
+      if (secret) {
+        const fresh = await makeWhitelistCookie(email, secret)
+        supabaseResponse.cookies.set(WHITELIST_COOKIE_NAME, fresh, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === "production",
+          sameSite: "lax",
+          maxAge: WHITELIST_COOKIE_MAX_AGE_SECONDS,
+          path: "/",
+        })
+      }
+    }
   }
 
   return supabaseResponse

--- a/lib/supabase/storage.ts
+++ b/lib/supabase/storage.ts
@@ -10,19 +10,9 @@ export interface UploadResult {
 }
 
 export async function uploadFile(supabase: SupabaseClient, file: File, folder = "general"): Promise<UploadResult> {
-  console.log("[v0] uploadFile - Starting upload:", {
-    fileName: file.name,
-    fileSize: file.size,
-    folder,
-    bucket: BUCKET_NAME,
-  })
-
-  // Generate unique file name
   const timestamp = Date.now()
   const sanitizedName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_")
   const filePath = `${folder}/${timestamp}_${sanitizedName}`
-
-  console.log("[v0] uploadFile - File path:", filePath)
 
   const { data, error } = await supabase.storage.from(BUCKET_NAME).upload(filePath, file, {
     cacheControl: "3600",
@@ -30,16 +20,9 @@ export async function uploadFile(supabase: SupabaseClient, file: File, folder = 
   })
 
   if (error) {
-    console.error("[v0] uploadFile - Upload error:", {
-      message: error.message,
-      name: error.name,
-      cause: error.cause,
-      fullError: JSON.stringify(error),
-    })
+    console.error("uploadFile error:", error.message)
     return { success: false, error: error.message }
   }
-
-  console.log("[v0] uploadFile - Upload successful:", data)
 
   // El bucket es privado. Devolvemos la URL del proxy autenticado en /api/files
   // (ver app/api/files/[...path]/route.ts). Esa ruta valida sesion + whitelist

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@supabase/auth-helpers-nextjs": "0.10.0",
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
+    "@tanstack/react-query": "^5.101.0",
     "@vercel/analytics": "1.3.1",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",

--- a/scripts/011_dashboard_rpc.sql
+++ b/scripts/011_dashboard_rpc.sql
@@ -1,0 +1,86 @@
+-- =============================================================================
+-- RPC: get_dashboard_stats
+-- =============================================================================
+-- Devuelve en un solo round-trip todos los agregados que consume el
+-- dashboard (KPIs, casos por año, por provincia, por estado procesal).
+--
+-- Reemplaza a 4-5 queries del cliente que bajaban tablas enteras y
+-- contaban en JS. El payload pasa de varios KB por query a ~1 KB total.
+--
+-- Seguridad: `security invoker` -> respeta las policies RLS del caller.
+-- Con las policies actuales (`Allow all operations`) el resultado es
+-- accesible para anon, igual que las queries directas que reemplaza.
+--
+-- Ejecutar UNA vez en SQL Editor del proyecto Supabase.
+-- -----------------------------------------------------------------------------
+
+create or replace function public.get_dashboard_stats()
+returns jsonb
+language sql
+stable
+security invoker
+as $$
+  with kpis as (
+    select
+      (select count(*) from public.victimas) as total_cases,
+      (select count(*) from public.victimas
+         where created_at >= now() - interval '1 year') as cases_last_year,
+      (select count(*) from public.imputados
+         where coalesce(estado_procesal, '') <> 'Condenado') as cases_without_conviction,
+      (select count(*) from public.imputados
+         where estado_procesal = 'En investigación') as cases_in_investigation
+  ),
+  by_year as (
+    select coalesce(
+      jsonb_agg(jsonb_build_object('year', year::text, 'cases', cases) order by year),
+      '[]'::jsonb
+    ) as data
+    from (
+      select extract(year from fecha_hecho)::int as year, count(*)::int as cases
+      from public.hechos
+      where fecha_hecho is not null
+      group by extract(year from fecha_hecho)
+    ) y
+  ),
+  by_province as (
+    select coalesce(
+      jsonb_agg(jsonb_build_object('provincia', provincia, 'cases', cases) order by cases desc),
+      '[]'::jsonb
+    ) as data
+    from (
+      select provincia, count(*)::int as cases
+      from public.hechos
+      where provincia is not null
+      group by provincia
+    ) p
+  ),
+  by_status as (
+    select coalesce(
+      jsonb_agg(jsonb_build_object('status', status, 'cases', cases) order by cases desc),
+      '[]'::jsonb
+    ) as data
+    from (
+      select coalesce(estado_procesal, 'Otros') as status, count(*)::int as cases
+      from public.imputados
+      group by coalesce(estado_procesal, 'Otros')
+    ) s
+  )
+  select jsonb_build_object(
+    'kpis', jsonb_build_object(
+      'totalCases',              k.total_cases,
+      'casesLastYear',           k.cases_last_year,
+      'casesWithoutConviction',  k.cases_without_conviction,
+      'casesInInvestigation',    k.cases_in_investigation
+    ),
+    'casesByYear',     y.data,
+    'casesByProvince', p.data,
+    'casesByStatus',   s.data
+  )
+  from kpis k, by_year y, by_province p, by_status s;
+$$;
+
+-- Permitir invocar la RPC desde el frontend (anon + usuarios autenticados).
+grant execute on function public.get_dashboard_stats() to anon, authenticated;
+
+-- Verificar:
+--   select public.get_dashboard_stats();

--- a/scripts/012_performance_indexes.sql
+++ b/scripts/012_performance_indexes.sql
@@ -1,0 +1,36 @@
+-- =============================================================================
+-- Indexes faltantes detectados en la auditoría de performance.
+-- =============================================================================
+-- Volúmenes actuales son chicos (cientos de filas), así que el impacto
+-- inmediato es bajo. Estos indexes son "future-proofing" — apuntan a
+-- queries que se ejecutan en hot paths:
+--
+--   - `casos` ordenado por created_at desc      -> listados de casos
+--   - `allowed_users` lookup por email          -> middleware en cada request
+--   - `recursos` filtrado por victima_id        -> detalle de caso
+--   - `instancias_judiciales` por imputado_id   -> detalle de caso (embed)
+--
+-- Todos con `if not exists` para que sea idempotente.
+-- Ejecutar UNA vez en SQL Editor del proyecto Supabase.
+-- -----------------------------------------------------------------------------
+
+create index if not exists idx_casos_created_at_desc
+  on public.casos (created_at desc);
+
+create unique index if not exists idx_allowed_users_email
+  on public.allowed_users (email);
+
+create index if not exists idx_recursos_victima_id
+  on public.recursos (victima_id)
+  where victima_id is not null;
+
+create index if not exists idx_instancias_judiciales_imputado_id
+  on public.instancias_judiciales (imputado_id);
+
+-- Verificación:
+--   select schemaname, tablename, indexname
+--   from pg_indexes
+--   where indexname like 'idx_casos_created_at_desc'
+--      or indexname like 'idx_allowed_users_email'
+--      or indexname like 'idx_recursos_victima_id'
+--      or indexname like 'idx_instancias_judiciales_imputado_id';


### PR DESCRIPTION
Draft PR para generar el preview de Vercel y revisar visualmente los cambios antes de mergear.

## Cambios (8 commits)

**Performance**
- `lib/data/casos.ts` (nuevo) + uso en listados: elimina N+1 con embedded selects de PostgREST.
- `lib/data/dashboard.ts`: una sola llamada RPC (`get_dashboard_stats`) en vez de N queries.
- TanStack Query como capa de cache cliente (`lib/queries/*`, `components/providers/query-provider.tsx`).
- `components/cases/case-detail-content.tsx`: `Promise.all` para paralelizar carga del detalle.
- `components/cases/animated-cases-grid.tsx`: vitrina limitada a 24 casos + `content-visibility: auto` + `will-change: transform`.

**Auth**
- `lib/auth/whitelist-cookie.ts` (nuevo): cache HMAC-firmado del whitelist lookup (TTL 15min).
- `lib/supabase/middleware.ts`: usa el cache + redirige `/login` → `/` si ya hay sesión.
- `components/auth/auth-guard.tsx`: elimina spinner bloqueante de "Verificando acceso" (la validación es server-side ahora).

**DB scripts (manual)**
- `scripts/011_dashboard_rpc.sql` — **REQUERIDO** para que funcione el dashboard.
- `scripts/012_performance_indexes.sql` — indexes opcionales.

**Bugs en case-form**
- Bucket de storage equivocado (`case-files` → `archivos-casos`): los archivos no se borraban.
- `.single()` → `.maybeSingle()` en carga de seguimiento (crasheaba en fichas viejas).
- Edición de recursos existentes no persistía (rama `update` faltaba).
- Helpers `isExistingResource()` / `buildResourceUpdate()` extraídos.
- Cleanup de estado muerto (`victimResources`, doble `setFormData`, log de hot-path).

## Pendiente antes de mergear
- [ ] Ejecutar `scripts/011_dashboard_rpc.sql` en Supabase SQL Editor.
- [ ] (Opcional) Ejecutar `scripts/012_performance_indexes.sql`.
- [ ] Setear `WHITELIST_COOKIE_SECRET` en Vercel (env var nueva).
- [ ] `npm install` en local (se agregó `@tanstack/react-query`).

## Test plan
- [ ] Login + navegar a `/` y `/casos` — ya no aparece el spinner "Verificando acceso".
- [ ] Dashboard carga sin errores 404 (requiere haber corrido el SQL).
- [ ] Crear ficha nueva → aparece en el listado sin recargar.
- [ ] Editar ficha existente → cambios en recursos persisten (no se pierden).
- [ ] Borrar un recurso con archivo → el archivo se elimina del bucket.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgxBaGA5MJ1mBWcXucoHfd)_