### PR TITLE
fix(storage): eliminar huérfanos al borrar fichas e imputados + limpieza histórica

### DIFF
--- a/components/cases/case-detail-content.tsx
+++ b/components/cases/case-detail-content.tsx
@@ -71,6 +71,7 @@ interface Victima {
 
 interface Hecho {
   id: string
+  victima_id: string | null
   fecha_hecho: string | null
   fecha_fallecimiento: string | null
   municipio: string | null
@@ -539,11 +540,86 @@ export function CaseDetailContent({ caseId }: CaseDetailContentProps) {
     })
   }
 
+  /**
+   * Borrado completo de la ficha.
+   *
+   * Los FK apuntan de `casos` hacia `victimas`/`hechos`, así que borrar
+   * sólo la fila de `casos` dejaba huérfanos en BD (víctima, hecho,
+   * imputados, recursos) y en storage (archivos adjuntos). Acá se borra
+   * todo explícitamente, sin depender de cascades cuya configuración en
+   * producción no está versionada.
+   *
+   * Caso especial: si el hecho es compartido con fichas hermanas
+   * (varias víctimas del mismo hecho), sólo se purga lo propio de esta
+   * víctima — el hecho, sus imputados y sus archivos siguen en uso.
+   */
   const handleDelete = async () => {
+    if (!caseData) return
+    const run = async (query: PromiseLike<{ error: any }>) => {
+      const { error } = await query
+      if (error) throw error
+    }
     try {
       setIsDeleting(true)
-      const { error } = await supabase.from("casos").delete().eq("id", caseId)
-      if (error) throw error
+
+      const victimaId = caseData.victima?.id ?? null
+      const hechoId = caseData.hecho?.id ?? null
+      const hasSiblings = caseData.hermanos_hecho.length > 0
+      const imputadoIds = caseData.imputados.map((i) => i.id)
+
+      // 1. Archivos del bucket. Con hermanos sólo los recursos de la
+      //    víctima; sin hermanos, todos los de la ficha. Si el remove
+      //    falla seguimos igual: preferimos un archivo huérfano a una
+      //    ficha a medio borrar.
+      const recursosToPurge = hasSiblings
+        ? caseData.recursos.filter((r) => r.victima_id === victimaId)
+        : caseData.recursos
+      const storagePaths = recursosToPurge
+        .map((r) => r.archivo_path)
+        .filter((p): p is string => !!p)
+      if (storagePaths.length > 0) {
+        await supabase.storage.from("archivos-casos").remove(storagePaths)
+      }
+
+      // 2. Filas en BD, de hijos a padres.
+      if (!hasSiblings && hechoId) {
+        if (imputadoIds.length > 0) {
+          await run(supabase.from("fechas_juicio").delete().in("imputado_id", imputadoIds))
+          await run(supabase.from("instancias_judiciales").delete().in("imputado_id", imputadoIds))
+          await run(supabase.from("recursos").delete().in("imputado_id", imputadoIds))
+        }
+        await run(supabase.from("recursos").delete().eq("hecho_id", hechoId))
+        if (victimaId) {
+          await run(supabase.from("recursos").delete().eq("victima_id", victimaId))
+        }
+        await run(supabase.from("imputados").delete().eq("hecho_id", hechoId))
+        await run(supabase.from("seguimiento").delete().eq("hecho_id", hechoId))
+        await run(supabase.from("casos").delete().eq("hecho_id", hechoId))
+        await run(supabase.from("hechos").delete().eq("id", hechoId))
+      } else if (victimaId) {
+        // Hecho compartido: borrar sólo lo propio de esta víctima.
+        await run(supabase.from("recursos").delete().eq("victima_id", victimaId))
+        // `hechos.victima_id` tiene ON DELETE CASCADE: si apunta a esta
+        // víctima hay que reasignarlo a un hermano antes de borrarla, o
+        // el hecho entero (y las fichas hermanas) se irían con ella.
+        if (hechoId && caseData.hecho?.victima_id === victimaId) {
+          await run(
+            supabase
+              .from("hechos")
+              .update({ victima_id: caseData.hermanos_hecho[0].victima_id })
+              .eq("id", hechoId),
+          )
+        }
+        await run(supabase.from("casos").delete().eq("id", caseId))
+      }
+
+      if (victimaId) {
+        // Cascadea la fila de `casos` (casos.victima_id) si quedara viva.
+        await run(supabase.from("victimas").delete().eq("id", victimaId))
+      } else {
+        await run(supabase.from("casos").delete().eq("id", caseId))
+      }
+
       // Listados y dashboard quedaron stale tras el delete.
       queryClient.invalidateQueries({ queryKey: queryKeys.casesList })
       queryClient.invalidateQueries({ queryKey: queryKeys.dashboardStats })

--- a/components/cases/case-form.tsx
+++ b/components/cases/case-form.tsx
@@ -674,6 +674,25 @@ export function CaseForm({ mode, caseId }: CaseFormProps) {
 
           // Delete imputados that were removed from the form (diffing)
           const imputadosToDelete = existingImputadoIds.filter((id) => !formImputadoIds.includes(id))
+
+          // Purgar del bucket los archivos de los recursos de estos
+          // imputados ANTES de borrar las filas, o quedan huérfanos en
+          // storage sin forma de rastrearlos.
+          if (imputadosToDelete.length > 0) {
+            const { data: recursosConArchivo } = await supabase
+              .from("recursos")
+              .select("archivo_path")
+              .in("imputado_id", imputadosToDelete)
+              .not("archivo_path", "is", null)
+
+            const pathsToRemove = (recursosConArchivo || [])
+              .map((r) => r.archivo_path)
+              .filter((p): p is string => !!p)
+            if (pathsToRemove.length > 0) {
+              await supabase.storage.from("archivos-casos").remove(pathsToRemove)
+            }
+          }
+
           for (const idToDelete of imputadosToDelete) {
             // First delete related records
             await supabase.from("recursos").delete().eq("imputado_id", idToDelete)

--- a/scripts/013_audit_orphan_storage.sql
+++ b/scripts/013_audit_orphan_storage.sql
@@ -1,0 +1,50 @@
+-- =============================================================================
+-- Auditoría de archivos huérfanos en storage (SOLO LECTURA).
+-- =============================================================================
+-- Lista los objetos del bucket `archivos-casos` que ninguna fila de
+-- `recursos.archivo_path` referencia. Son archivos que quedaron de
+-- borrados viejos que no limpiaban el storage.
+--
+-- Ejecutar en el SQL Editor de Supabase. No modifica nada.
+--
+-- Para BORRAR los huérfanos usar `scripts/cleanup-orphan-files.mjs`
+-- (el borrado debe ir por el API de storage, no por SQL directo: borrar
+-- filas de storage.objects deja basura en el backend de archivos).
+-- -----------------------------------------------------------------------------
+
+-- 1. Huérfanos: en el bucket pero sin fila en recursos
+select
+  o.name as archivo,
+  o.created_at,
+  pg_size_pretty((o.metadata ->> 'size')::bigint) as tamano
+from storage.objects o
+where o.bucket_id = 'archivos-casos'
+  and not exists (
+    select 1 from public.recursos r where r.archivo_path = o.name
+  )
+order by o.created_at;
+
+-- 2. Caso inverso: filas de recursos que apuntan a archivos inexistentes
+--    (links rotos en la UI; revisar a mano)
+select
+  r.id,
+  r.titulo,
+  r.archivo_path,
+  r.created_at
+from public.recursos r
+where r.archivo_path is not null
+  and not exists (
+    select 1 from storage.objects o
+    where o.bucket_id = 'archivos-casos' and o.name = r.archivo_path
+  )
+order by r.created_at;
+
+-- 3. Resumen rápido
+select
+  (select count(*) from storage.objects where bucket_id = 'archivos-casos') as archivos_en_bucket,
+  (select count(distinct archivo_path) from public.recursos where archivo_path is not null) as paths_referenciados,
+  (select count(*)
+     from storage.objects o
+     where o.bucket_id = 'archivos-casos'
+       and not exists (select 1 from public.recursos r where r.archivo_path = o.name)
+  ) as huerfanos;

--- a/scripts/cleanup-orphan-files.mjs
+++ b/scripts/cleanup-orphan-files.mjs
@@ -1,0 +1,154 @@
+// =============================================================================
+// Limpieza de archivos huérfanos en el bucket `archivos-casos`.
+// =============================================================================
+// Compara los objetos del bucket contra `recursos.archivo_path`. Todo
+// archivo del bucket que ninguna fila de `recursos` referencia es un
+// huérfano (quedó de borrados viejos que no limpiaban storage).
+//
+// Uso (desde la raíz del repo, con Node 18+):
+//
+//   # 1. Dry-run: lista los huérfanos, NO borra nada
+//   SUPABASE_URL=https://<proyecto>.supabase.co \
+//   SUPABASE_SERVICE_ROLE_KEY=<service-role-key> \
+//   node scripts/cleanup-orphan-files.mjs
+//
+//   # 2. Borrado real (después de revisar el dry-run)
+//   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+//   node scripts/cleanup-orphan-files.mjs --delete
+//
+// Requiere la SERVICE ROLE key (no la anon) porque el bucket es privado
+// y el borrado vía API necesita permisos plenos. NO commitear la key ni
+// pegarla en ningún chat; pasala sólo como variable de entorno.
+// =============================================================================
+
+import { createClient } from "@supabase/supabase-js"
+
+const BUCKET = "archivos-casos"
+const DELETE_MODE = process.argv.includes("--delete")
+
+const url = process.env.SUPABASE_URL
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!url || !key) {
+  console.error("Faltan SUPABASE_URL y/o SUPABASE_SERVICE_ROLE_KEY en el entorno.")
+  process.exit(1)
+}
+
+const supabase = createClient(url, key)
+
+/** Lista recursivamente todos los archivos del bucket. */
+async function listAllFiles(prefix = "") {
+  const files = []
+  let offset = 0
+  const PAGE = 1000
+
+  while (true) {
+    const { data, error } = await supabase.storage.from(BUCKET).list(prefix, {
+      limit: PAGE,
+      offset,
+      sortBy: { column: "name", order: "asc" },
+    })
+    if (error) throw new Error(`Error listando "${prefix}": ${error.message}`)
+    if (!data || data.length === 0) break
+
+    for (const entry of data) {
+      const fullPath = prefix ? `${prefix}/${entry.name}` : entry.name
+      if (entry.id === null) {
+        // Sin id = es una "carpeta" (prefijo). Descender.
+        files.push(...(await listAllFiles(fullPath)))
+      } else {
+        files.push(fullPath)
+      }
+    }
+
+    if (data.length < PAGE) break
+    offset += PAGE
+  }
+
+  return files
+}
+
+/** Trae todos los archivo_path referenciados en la tabla recursos. */
+async function listReferencedPaths() {
+  const paths = new Set()
+  let from = 0
+  const PAGE = 1000
+
+  while (true) {
+    const { data, error } = await supabase
+      .from("recursos")
+      .select("archivo_path")
+      .not("archivo_path", "is", null)
+      .range(from, from + PAGE - 1)
+    if (error) throw new Error(`Error leyendo recursos: ${error.message}`)
+    if (!data || data.length === 0) break
+
+    for (const row of data) {
+      if (row.archivo_path) paths.add(row.archivo_path)
+    }
+    if (data.length < PAGE) break
+    from += PAGE
+  }
+
+  return paths
+}
+
+async function main() {
+  console.log(`Bucket: ${BUCKET}`)
+  console.log(`Modo: ${DELETE_MODE ? "BORRADO REAL" : "dry-run (no borra nada)"}\n`)
+
+  const [allFiles, referenced] = await Promise.all([listAllFiles(), listReferencedPaths()])
+
+  console.log(`Archivos en el bucket:        ${allFiles.length}`)
+  console.log(`Paths referenciados en BD:    ${referenced.size}`)
+
+  const orphans = allFiles.filter((f) => !referenced.has(f))
+
+  // Sanity check inverso: filas de recursos cuyo archivo ya no existe.
+  const filesSet = new Set(allFiles)
+  const danglingRows = [...referenced].filter((p) => !filesSet.has(p))
+
+  console.log(`Huérfanos (en bucket, sin fila): ${orphans.length}`)
+  console.log(`Filas con archivo inexistente:   ${danglingRows.length}\n`)
+
+  if (danglingRows.length > 0) {
+    console.log("⚠ Filas de `recursos` que apuntan a archivos que ya no existen")
+    console.log("  (revisar a mano, este script no las toca):")
+    for (const p of danglingRows) console.log(`  - ${p}`)
+    console.log("")
+  }
+
+  if (orphans.length === 0) {
+    console.log("No hay archivos huérfanos. Nada que hacer.")
+    return
+  }
+
+  console.log("Archivos huérfanos:")
+  for (const f of orphans) console.log(`  - ${f}`)
+
+  if (!DELETE_MODE) {
+    console.log(`\nDry-run terminado. Para borrarlos de verdad: agregá --delete`)
+    return
+  }
+
+  // El API de storage acepta hasta ~100 paths por llamada con seguridad.
+  const CHUNK = 100
+  let deleted = 0
+  for (let i = 0; i < orphans.length; i += CHUNK) {
+    const chunk = orphans.slice(i, i + CHUNK)
+    const { error } = await supabase.storage.from(BUCKET).remove(chunk)
+    if (error) {
+      console.error(`Error borrando lote ${i / CHUNK + 1}: ${error.message}`)
+      process.exit(1)
+    }
+    deleted += chunk.length
+    console.log(`Borrados ${deleted}/${orphans.length}...`)
+  }
+
+  console.log(`\n✔ Limpieza completa: ${deleted} archivos huérfanos eliminados.`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Problema

Borrar una ficha solo eliminaba la fila de `casos`. Los FK apuntan de `casos` hacia `victimas`/`hechos`, así que **nada cascadeaba**: quedaban huérfanos en la BD (víctima, hecho, imputados, recursos, seguimiento) y en storage (archivos adjuntos). Lo mismo al quitar un imputado en edición: se borraban sus filas de `recursos` sin tocar los archivos.

## Cambios

**1. Borrado completo de ficha** (`case-detail-content.tsx`)
- Sin hermanos de hecho: purga archivos del bucket + borra en orden hijo→padre todas las filas (fechas_juicio, instancias, recursos, imputados, seguimiento, casos, hecho, víctima).
- Con hermanos (hecho compartido entre víctimas): solo purga lo propio de la víctima. Si `hechos.victima_id` apuntaba a ella, se reasigna a un hermano antes de borrarla — su `ON DELETE CASCADE` arrastraría el hecho completo y las fichas hermanas.

**2. Quitar imputado en edición** (`case-form.tsx`): purga del bucket los archivos de sus recursos antes de borrar las filas.

**3. `scripts/cleanup-orphan-files.mjs`**: limpieza one-shot de huérfanos históricos (6+ meses acumulados). Dry-run por defecto, `--delete` para borrar de verdad. Requiere service role key por env var.

**4. `scripts/013_audit_orphan_storage.sql`**: auditoría de solo lectura desde el SQL Editor.

## ⚠️ Para probar

**El preview usa la misma BD de producción.** Borrar una ficha desde el preview la borra DE VERDAD. Para probar:
1. Crear una ficha de prueba con un archivo adjunto.
2. Borrarla.
3. Verificar en Supabase → Storage → `archivos-casos` que el archivo desapareció.
4. Verificar en Table Editor que no quedaron filas en `victimas`/`hechos`/`recursos`.

## Test plan
- [ ] Correr query 3 de `013_audit_orphan_storage.sql` (resumen de huérfanos actuales)
- [ ] Crear y borrar ficha de prueba con archivo → verificar limpieza total
- [ ] Borrar ficha con hermanos de hecho → verificar que las fichas hermanas siguen intactas
- [ ] Editar ficha quitando un imputado con archivos → verificar que sus archivos se fueron del bucket
- [ ] Correr `cleanup-orphan-files.mjs` en dry-run, revisar la lista, después `--delete`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgxBaGA5MJ1mBWcXucoHfd)_